### PR TITLE
Add Baserow sync for player data

### DIFF
--- a/python/WOM.py
+++ b/python/WOM.py
@@ -212,16 +212,15 @@ async def list_all_members_and_ranks():
             memberships = group.memberships
             group_name = group.name
 
-            # Build list of players with EHB > 0
+            # Build list of players including those with 0 EHB
             players = []
             for membership in memberships:
                 try:
                     player = membership.player
                     username = player.display_name
                     ehb = round(player.ehb, 2)
-                    if ehb > 0:
-                        rank = get_rank(ehb)
-                        players.append((username, rank, ehb))
+                    rank = get_rank(ehb)
+                    players.append((username, rank, ehb))
                 except Exception as e:
                     player_name = getattr(membership.player, "display_name", "Unknown")
                     log(f"Error processing player data for {player_name}: {e}")

--- a/python/utils/baserow_connect.py
+++ b/python/utils/baserow_connect.py
@@ -7,7 +7,7 @@ from datetime import datetime
 config = configparser.ConfigParser()
 config_file = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'config.ini')
 config.read(config_file)
-token = str(config['baserow']['token'])
+token = config.get('baserow', 'token', fallback='')
 
 if not token:
     raise ValueError("Baserow token is not set in the config.ini file.")
@@ -29,3 +29,47 @@ def post_to_ehb_table(username, date, ehb):
 
     if post.status_code != 200:
         print("Error: ", post.status_code)
+
+
+def update_players_table(username, rank, ehb, discord_names=None):
+    """Create or update a row in the players table (id 613980)."""
+
+    base_url = "https://api.baserow.io/api/database/rows/table/613980/"
+    headers = {
+        "Authorization": f"Token {token}",
+        "Content-Type": "application/json",
+    }
+
+    # Convert list of discord names to comma separated string if provided
+    if isinstance(discord_names, list):
+        discord_value = ", ".join(discord_names)
+    else:
+        discord_value = discord_names or ""
+
+    # Check if the player already exists
+    get = requests.get(
+        f"{base_url}?user_field_names=true&filter__Username__equal={username}",
+        headers=headers,
+    )
+
+    if get.status_code == 200:
+        data = get.json()
+        if data.get("results"):
+            row_id = data["results"][0]["id"]
+            patch = requests.patch(
+                f"{base_url}{row_id}/?user_field_names=true",
+                headers=headers,
+                json={"Username": username, "Rank": rank, "EHB": ehb, "Discord": discord_value},
+            )
+            if patch.status_code != 200:
+                print("Error updating player row: ", patch.status_code)
+        else:
+            post = requests.post(
+                f"{base_url}?user_field_names=true",
+                headers=headers,
+                json={"Username": username, "Rank": rank, "EHB": ehb, "Discord": discord_value},
+            )
+            if post.status_code != 200:
+                print("Error creating player row: ", post.status_code)
+    else:
+        print("Error fetching player row: ", get.status_code)

--- a/python/utils/rank_utils.py
+++ b/python/utils/rank_utils.py
@@ -1,6 +1,7 @@
 import json
 import os
 import configparser
+from .baserow_connect import update_players_table
 
 # JSON file for storing player ranks
 RANKS_FILE = os.path.join(os.path.dirname(__file__), 'player_ranks.json')
@@ -30,6 +31,16 @@ def save_ranks(data):
     """Save ranks to a JSON file."""
     with open(RANKS_FILE, 'w') as f:
         json.dump(data, f, indent=4)
+
+    # Sync data to Baserow players table
+    try:
+        for username, pdata in data.items():
+            rank = pdata.get("rank", "")
+            ehb = pdata.get("last_ehb", 0)
+            discord_names = pdata.get("discord_name", [])
+            update_players_table(username, rank, ehb, discord_names)
+    except Exception as e:
+        print(f"Error updating Baserow players table: {e}")
 
 def next_rank(username):
     """Returns the next rank for a given player based on their current EHB."""


### PR DESCRIPTION
## Summary
- update `list_all_members_and_ranks` to include players with 0 EHB
- connect to Baserow players table
- sync player data to Baserow whenever ranks are saved
- provide stub `requests` and config in tests
- test that Baserow sync is triggered on save

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ec4755afc8326819ce43692def8c9