### PR TITLE
Fix CSV logging path to avoid permission errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The bot automatically tracks ranks based on your configuration. Below are all av
 **Note**: For usernames with spaces, enclose them in quotes (e.g., "/update 'Player Name'")
 
 ## Logging
-- EHB values are logged to `ehb_log.csv`
+- EHB values are logged to `python/ehb_log.csv` by default (the path is resolved relative to the `python` folder so you can run the bot from anywhere).
 - Configure logging behavior in `config.ini`:
   - `PRINT_TO_CSV`: Enable/disable CSV logging
   - `print_csv_changes`: Enable/disable console logging of CSV updates

--- a/python/utils/log_csv.py
+++ b/python/utils/log_csv.py
@@ -1,16 +1,32 @@
 #log_csv.py
 import csv
+import os
 from datetime import datetime
+
+
+def _resolve_csv_path(file_name: str) -> str:
+    """Return an absolute, writable-friendly path for the CSV log."""
+    if os.path.isabs(file_name):
+        return file_name
+
+    # Place logs beside WOM.py (../ehb_log.csv) instead of depending on cwd
+    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    return os.path.join(base_dir, file_name)
+
 
 def log_ehb_to_csv(username, ehb, file_name="ehb_log.csv", print_csv_changes=True):
     """Logs the username, EHB value, and timestamp to a CSV file."""
+    resolved_path = _resolve_csv_path(file_name)
     try:
-        with open(file_name, mode="a", newline="", encoding="utf-8") as file:
+        with open(resolved_path, mode="a", newline="", encoding="utf-8") as file:
             writer = csv.writer(file)
             timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             writer.writerow([timestamp, username, ehb])
             if print_csv_changes:
                 timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                print(f"{timestamp} - Logged {username} with {ehb} EHB at {timestamp} to {file_name}.")
+                print(
+                    f"{timestamp} - Logged {username} with {ehb} EHB at {timestamp} "
+                    f"to {resolved_path}."
+                )
     except Exception as e:
-        print(f"Error logging to CSV: {e}")
+        print(f"Error logging to CSV at {resolved_path}: {e}")


### PR DESCRIPTION
## Summary
- resolve CSV logging to an absolute path beside WOM.py so runs outside the project root don’t fail with permission errors
- clarify logging location and behavior in the README

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692e221a25608326a3e227a33de8239b)