### PR TITLE
Log web UI URL to terminal when server is ready

### DIFF
--- a/python/WOM.py
+++ b/python/WOM.py
@@ -441,13 +441,12 @@ if __name__ == "__main__":
                 tasks_to_run = [discord_client.start(discord_token)]
 
                 if web_enabled:
-                    web_app = create_app(bot_state)
+                    web_app = create_app(bot_state, host=web_host, port=web_port, log_func=log)
                     uvi_config = uvicorn.Config(
                         web_app, host=web_host, port=web_port, log_level="info"
                     )
                     server = uvicorn.Server(uvi_config)
                     tasks_to_run.append(server.serve())
-                    log(f"Web interface starting on http://{web_host}:{web_port}")
 
                 await asyncio.gather(*tasks_to_run)
         

--- a/python/web/app.py
+++ b/python/web/app.py
@@ -13,12 +13,18 @@ from .services.bot_state import BotState
 _BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-def create_app(state: BotState) -> FastAPI:
+def create_app(state: BotState, host: str = "0.0.0.0", port: int = 8080, log_func=None) -> FastAPI:
     """Build and return the configured FastAPI application."""
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         app.state.bot_state = state
+        display_host = "localhost" if host in ("0.0.0.0", "") else host
+        url = f"http://{display_host}:{port}"
+        if log_func:
+            log_func(f"Web UI is up and running at {url}")
+        else:
+            print(f"Web UI is up and running at {url}")
         yield
 
     app = FastAPI(title="WOMupdtr Dashboard", lifespan=lifespan)


### PR DESCRIPTION
Moves startup log from pre-launch to the lifespan startup handler so the
message fires only after uvicorn is actually serving requests. Displays
http://localhost:<port> (normalising 0.0.0.0 to localhost for readability).

https://claude.ai/code/session_01MkjkPDS4abhPjtWpGxy6vc