### PR TITLE
Restrict Docker dashboard port exposure to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ./python/ranks.ini:/app/python/ranks.ini:ro
       - ./data:/app/data
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     dns:
       - 8.8.8.8
       - 1.1.1.1


### PR DESCRIPTION
### Motivation
- The compose file published the FastAPI dashboard on all host interfaces which exposed unauthenticated admin endpoints; the change limits exposure by binding the published port to loopback.

### Description
- Replace the ports mapping in `docker-compose.yml` from `"8080:8080"` to `"127.0.0.1:8080:8080"` so the dashboard is only reachable from the host by default.

### Testing
- Attempted to validate the Compose configuration with `docker compose config` but the Docker CLI is not available in this environment, so the change was verified by inspecting `docker-compose.yml` contents and confirming the mapping now uses `127.0.0.1:8080:8080`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fa794c59b88326bee76f514d756baf)