### PR TITLE
Harden Claude workflow against untrusted @claude triggers

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,16 +13,31 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
-      id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
@@ -47,4 +62,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
### Motivation
- The existing workflow allowed any issue/PR comment or review containing `@claude` to run the Claude Code action with repository secrets and `id-token: write`, creating a high-risk secret-exfiltration attack surface. 
- The change enforces a trust gate and reduces privileges to follow least-privilege principles while preserving maintainer functionality.

### Description
- Added `author_association` checks so `@claude` invocations only run when the event author is one of `OWNER`, `MEMBER`, or `COLLABORATOR` across `issue_comment`, `pull_request_review_comment`, `pull_request_review`, and `issues` event paths using `fromJson(...)` and `contains(...)` expressions. 
- Removed the `id-token: write` permission from the job to reduce granted privileges. 
- Kept existing read permissions and the `anthropics/claude-code-action@v1` step intact so maintainers can still trigger the action with `@claude`.

### Testing
- Ran `sed -n '1,220p' .github/workflows/claude.yml` to inspect the file and it succeeded. 
- Verified the diff with `git diff -- .github/workflows/claude.yml` and committed the change with `git commit`, both of which succeeded. 
- Printed the final workflow with `nl -ba .github/workflows/claude.yml | sed -n '1,140p'` to confirm the updated `if` gate and permissions and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fa77c5d6ac8326b988216c0fa33f40)