### PR TITLE
Add EHP, gains snapshots, and monthly reports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Codex (Codex.ai/code) when working with code in t
 
 ## What this project is
 
-WOMupdtr is a Discord bot + FastAPI web dashboard for tracking EHB (Efficient Hours Bossed) based ranks for a Wise Old Man (OSRS) group. It automatically detects rank changes, sends Discord notifications, generates weekly/yearly reports, and provides a web dashboard.
+WOMupdtr is a Discord bot + FastAPI web dashboard for a Wise Old Man (OSRS) group. It tracks EHB-based bossing ranks, optionally tracks EHP-based skilling ranks, records configurable gains snapshots, announces rank changes, and generates weekly/yearly reports.
 
 ## Commands
 
@@ -12,50 +12,89 @@ WOMupdtr is a Discord bot + FastAPI web dashboard for tracking EHB (Efficient Ho
 # Install dependencies
 pip install -r python/requirements.txt
 
-# Run the bot (headless)
+# Run the bot (headless unless web.enabled is true)
 python python/WOM.py
 
 # Run with Docker (web dashboard at http://localhost:8080)
 docker compose up --build
 
-# Run tests
+# Run the full test suite
 pytest
 
-# Run a single test file
-pytest tests/test_rank_utils.py
+# Run focused rank/gains tests
+pytest tests/test_rank_utils.py tests/test_rank_utils_ehp.py tests/test_gains_snapshotter.py
 ```
 
 ## Architecture
 
 The bot (`python/WOM.py`) is the entry point. It:
-1. Starts the WOM API client and Discord client
-2. Launches periodic tasks: rank check loop (`check_interval`, default 3600s), group refresh (every 48h), weekly reporter (Sundays 6pm UTC), yearly reporter (Jan 1 noon UTC) #Monthly reporter not done yet!
-3. Optionally spawns a FastAPI web server (if `[web] enabled = true` in `config.ini`)
 
-**Shared state** between the bot and web server lives in `python/web/services/bot_state.py` (`BotState` dataclass).
+1. Initializes SQLite, imports legacy EHB CSV history when needed, and starts the WOM and Discord clients.
+2. Launches the rank check loop (`check_interval`, default 3600s), group refresh (every 48h), gains snapshotter, weekly reporter (Sundays 6pm UTC), and yearly reporter (Jan 1 noon UTC).
+3. Optionally starts FastAPI when `[web] enabled = true` in `config.ini`.
 
-### Core rank tracking loop (`WOM.py: check_for_rank_changes`)
-1. Fetch group member details from WOM API
-2. Compare each member's current EHB against `python/player_ranks.json`
-3. On EHB increase: send Discord notification, append to `ehb_log.csv`, update JSON, optionally sync to Baserow
+Shared bot/web state lives in `python/web/services/bot_state.py` (`BotState`). This now includes `last_gains_snapshot` in addition to the existing task status and callbacks.
+
+### Rank tracking loop (`WOM.py: check_for_rank_changes`)
+
+1. Fetch group member details from WOM.
+2. Calculate EHB rank from `[Group Ranking]`; when `track_ehp = true`, calculate EHP rank from `[Skilling Ranking]`.
+3. Use `rank_utils.compute_member_update()` to evaluate EHB and EHP independently and merge them without discarding other per-player fields.
+4. On EHB increase, notify Discord, append to the legacy EHB CSV when enabled, and update JSON/SQLite.
+5. On EHP increase, notify Discord with an EHP label and append to SQLite `ehp_history`.
+
+`python/player_ranks.json` remains the rank snapshot used by the bot and web UI. Entries always contain `last_ehb` and `rank`; EHP-enabled entries also contain `last_ehp` and `ehp_rank`. `save_ranks()` mirrors changed snapshots into SQLite while preserving optional/future fields. Manual `/update` changes only the EHB fields.
+
+### Gains tracking
+
+`python/gainstracker/gains_snapshotter.py` handles two related paths:
+
+- The background snapshotter fetches every configured WOM metric over a trailing window, paginates groups larger than 50, and writes the complete multi-metric snapshot atomically to SQLite `gains_history`. Invalid metrics are skipped, but a snapshot with no valid metrics fails; WOM page failures abort the snapshot so partial data is not persisted.
+- `/gains <metric> [days]` queries WOM live and returns a current leaderboard. It does not read the persisted snapshots.
+
+The scheduler runs immediately and then every `gains_snapshot_interval` seconds (minimum sleep 60s). It optionally posts the first configured metric's latest leaderboard to `gains_channel_id`; channel `0` still permits SQLite collection.
+
+### Persistence and web dashboard
+
+`python/utils/database.py` owns SQLite initialization and idempotent schema upgrades. The database path defaults to `python/database.db` and can be overridden with `WOM_DATABASE_PATH`. Relevant tables are `players`, `ehb_history`, `ehp_history`, `boss_kills_history`, and `gains_history`.
+
+The dashboard now exposes EHP and gains data:
+
+- Player lists/details include EHP and skilling rank alongside the existing EHB data.
+- `/charts/api/ehp-history?player=...` reads EHP history from SQLite.
+- `/charts/api/gains-history?player=...&metric=...` reads persisted gains history from SQLite.
+- The charts page renders individual EHB, EHP, and configurable-metric gains charts.
 
 ### Key modules
+
 | Path | Purpose |
 |---|---|
-| `python/WOM.py` | Entry point, rank check loop, periodic tasks |
-| `python/utils/commands.py` | All 20+ slash commands (large file, needs splitting) |
-| `python/utils/rank_utils.py` | Load/save ranks, next rank threshold, Baserow sync |
-| `python/utils/log_csv.py` | Append-only EHB CSV logging |
+| `python/WOM.py` | Entry point, bot lifecycle, rank checks, and periodic task startup |
+| `python/utils/commands.py` | Discord slash commands, including `/ehpladder` and live `/gains` |
+| `python/utils/rank_utils.py` | Shared EHB/EHP threshold parsing, state merging, JSON persistence, and next-rank helpers |
+| `python/utils/database.py` | SQLite schema/migrations and EHB, EHP, boss, gains, and player persistence |
+| `python/gainstracker/` | WOM gains collection, formatting, persistence, and scheduler |
+| `python/utils/log_csv.py` | Legacy append-only EHB CSV logging |
 | `python/weeklyupdater/` | Weekly and yearly report generation + scheduling |
-| `python/web/` | FastAPI app, routers, Jinja2 templates, static assets |
-| `python/web/routers/` | One router per section: dashboard, players, reports, charts, admin, group |
+| `python/web/` | FastAPI routers, services, Jinja2 templates, and static assets |
 
-### Configuration
-- `python/config.ini` — Discord token, WOM group ID, channel IDs, feature flags (`post_to_discord`, `silent_mode`, `debug`, etc.)
-- `python/ranks.ini` — EHB thresholds for 10 rank tiers (Goblin → Zenyte)
-- Docker: `config.ini` and `ranks.ini` mounted read-only; CSV logs persisted via `./data` volume with `EHB_LOG_PATH=/app/data/ehb_log.csv`
+## Configuration
 
-### Known technical debt (from `rmap.md`)
-- `commands.py` is 540+ lines in a single `setup_commands()` function — should be split by category
-- `WOM.py` has a duplicate `get_rank()` that overlaps with `rank_utils._get_rank_for_ehb()
-- Global state (`bot_state`, task handles) in `WOM.py` could be moved into a class
+- `python/config.ini` contains Discord/WOM credentials, channel IDs, feature flags, and intervals. New settings are `discord.gains_channel_id`, `settings.track_ehp`, `settings.gains_snapshot_interval`, `settings.gains_window_days`, and comma-separated `settings.gains_metrics`.
+- `python/ranks.ini` must contain `[Group Ranking]` for EHB. When EHP tracking is enabled it should also contain `[Skilling Ranking]`; copy `python/ranks.ini.example` for both ladders.
+- Gains defaults are a daily snapshot (`86400`) of a trailing 7-day window for `overall,ehb`. EHP tracking defaults off.
+- Docker mounts `config.ini` and `ranks.ini` read-only. CSV history can be redirected with `EHB_LOG_PATH`; SQLite can be redirected with `WOM_DATABASE_PATH`.
+
+## Testing notes
+
+- `tests/conftest.py` stubs optional runtime integrations and isolates rank/database paths.
+- `tests/test_rank_utils_ehp.py` covers dual EHB/EHP ranks, state preservation, missing sections, and next-rank behavior.
+- `tests/test_gains_snapshotter.py` covers pagination, metric resolution, leaderboard formatting, API failures, and atomic snapshots.
+- `tests/test_database.py` and `tests/test_web_routers.py` cover the new persistence and HTTP endpoints.
+
+## Known technical debt (from `rmap.md`)
+
+- `commands.py` still contains 20+ commands in one large `setup_commands()` function and should be split by category.
+- `WOM.py:get_rank()` is now only a compatibility wrapper over `rank_utils.get_rank_for_value()`; callers can eventually use the shared helper directly.
+- Global state (`bot_state`, task handles) in `WOM.py` could be moved into a class.
+- A monthly channel setting exists, but a monthly reporter is not implemented.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this project is
 
-WOMupdtr is a Discord bot + FastAPI web dashboard for tracking EHB (Efficient Hours Bossed) based ranks for a Wise Old Man (OSRS) group. It automatically detects rank changes, sends Discord notifications, generates weekly/yearly reports, and provides a web dashboard.
+WOMupdtr is a Discord bot + FastAPI web dashboard for a Wise Old Man (OSRS) group. It tracks EHB-based bossing ranks, optionally tracks EHP-based skilling ranks, records configurable gains snapshots, announces rank changes, and generates weekly/yearly reports.
 
 ## Commands
 
@@ -12,50 +12,89 @@ WOMupdtr is a Discord bot + FastAPI web dashboard for tracking EHB (Efficient Ho
 # Install dependencies
 pip install -r python/requirements.txt
 
-# Run the bot (headless)
+# Run the bot (headless unless web.enabled is true)
 python python/WOM.py
 
 # Run with Docker (web dashboard at http://localhost:8080)
 docker compose up --build
 
-# Run tests
+# Run the full test suite
 pytest
 
-# Run a single test file
-pytest tests/test_rank_utils.py
+# Run focused rank/gains tests
+pytest tests/test_rank_utils.py tests/test_rank_utils_ehp.py tests/test_gains_snapshotter.py
 ```
 
 ## Architecture
 
 The bot (`python/WOM.py`) is the entry point. It:
-1. Starts the WOM API client and Discord client
-2. Launches periodic tasks: rank check loop (`check_interval`, default 3600s), group refresh (every 48h), weekly reporter (Sundays 6pm UTC), yearly reporter (Jan 1 noon UTC)
-3. Optionally spawns a FastAPI web server (if `[web] enabled = true` in `config.ini`)
 
-**Shared state** between the bot and web server lives in `python/web/services/bot_state.py` (`BotState` dataclass).
+1. Initializes SQLite, imports legacy EHB CSV history when needed, and starts the WOM and Discord clients.
+2. Launches the rank check loop (`check_interval`, default 3600s), group refresh (every 48h), gains snapshotter, weekly reporter (Sundays 6pm UTC), and yearly reporter (Jan 1 noon UTC).
+3. Optionally starts FastAPI when `[web] enabled = true` in `config.ini`.
 
-### Core rank tracking loop (`WOM.py: check_for_rank_changes`)
-1. Fetch group member details from WOM API
-2. Compare each member's current EHB against `python/player_ranks.json`
-3. On EHB increase: send Discord notification, append to `ehb_log.csv`, update JSON, optionally sync to Baserow
+Shared bot/web state lives in `python/web/services/bot_state.py` (`BotState`). This now includes `last_gains_snapshot` in addition to the existing task status and callbacks.
+
+### Rank tracking loop (`WOM.py: check_for_rank_changes`)
+
+1. Fetch group member details from WOM.
+2. Calculate EHB rank from `[Group Ranking]`; when `track_ehp = true`, calculate EHP rank from `[Skilling Ranking]`.
+3. Use `rank_utils.compute_member_update()` to evaluate EHB and EHP independently and merge them without discarding other per-player fields.
+4. On EHB increase, notify Discord, append to the legacy EHB CSV when enabled, and update JSON/SQLite.
+5. On EHP increase, notify Discord with an EHP label and append to SQLite `ehp_history`.
+
+`python/player_ranks.json` remains the rank snapshot used by the bot and web UI. Entries always contain `last_ehb` and `rank`; EHP-enabled entries also contain `last_ehp` and `ehp_rank`. `save_ranks()` mirrors changed snapshots into SQLite while preserving optional/future fields. Manual `/update` changes only the EHB fields.
+
+### Gains tracking
+
+`python/gainstracker/gains_snapshotter.py` handles two related paths:
+
+- The background snapshotter fetches every configured WOM metric over a trailing window, paginates groups larger than 50, and writes the complete multi-metric snapshot atomically to SQLite `gains_history`. Invalid metrics are skipped, but a snapshot with no valid metrics fails; WOM page failures abort the snapshot so partial data is not persisted.
+- `/gains <metric> [days]` queries WOM live and returns a current leaderboard. It does not read the persisted snapshots.
+
+The scheduler runs immediately and then every `gains_snapshot_interval` seconds (minimum sleep 60s). It optionally posts the first configured metric's latest leaderboard to `gains_channel_id`; channel `0` still permits SQLite collection.
+
+### Persistence and web dashboard
+
+`python/utils/database.py` owns SQLite initialization and idempotent schema upgrades. The database path defaults to `python/database.db` and can be overridden with `WOM_DATABASE_PATH`. Relevant tables are `players`, `ehb_history`, `ehp_history`, `boss_kills_history`, and `gains_history`.
+
+The dashboard now exposes EHP and gains data:
+
+- Player lists/details include EHP and skilling rank alongside the existing EHB data.
+- `/charts/api/ehp-history?player=...` reads EHP history from SQLite.
+- `/charts/api/gains-history?player=...&metric=...` reads persisted gains history from SQLite.
+- The charts page renders individual EHB, EHP, and configurable-metric gains charts.
 
 ### Key modules
+
 | Path | Purpose |
 |---|---|
-| `python/WOM.py` | Entry point, rank check loop, periodic tasks |
-| `python/utils/commands.py` | All 20+ slash commands (large file, needs splitting) |
-| `python/utils/rank_utils.py` | Load/save ranks, next rank threshold, Baserow sync |
-| `python/utils/log_csv.py` | Append-only EHB CSV logging |
+| `python/WOM.py` | Entry point, bot lifecycle, rank checks, and periodic task startup |
+| `python/utils/commands.py` | Discord slash commands, including `/ehpladder` and live `/gains` |
+| `python/utils/rank_utils.py` | Shared EHB/EHP threshold parsing, state merging, JSON persistence, and next-rank helpers |
+| `python/utils/database.py` | SQLite schema/migrations and EHB, EHP, boss, gains, and player persistence |
+| `python/gainstracker/` | WOM gains collection, formatting, persistence, and scheduler |
+| `python/utils/log_csv.py` | Legacy append-only EHB CSV logging |
 | `python/weeklyupdater/` | Weekly and yearly report generation + scheduling |
-| `python/web/` | FastAPI app, routers, Jinja2 templates, static assets |
-| `python/web/routers/` | One router per section: dashboard, players, reports, charts, admin, group |
+| `python/web/` | FastAPI routers, services, Jinja2 templates, and static assets |
 
-### Configuration
-- `python/config.ini` — Discord token, WOM group ID, channel IDs, feature flags (`post_to_discord`, `silent_mode`, `debug`, etc.)
-- `python/ranks.ini` — EHB thresholds for 10 rank tiers (Goblin → Zenyte)
-- Docker: `config.ini` and `ranks.ini` mounted read-only; CSV logs persisted via `./data` volume with `EHB_LOG_PATH=/app/data/ehb_log.csv`
+## Configuration
 
-### Known technical debt (from `rmap.md`)
-- `commands.py` is 540+ lines in a single `setup_commands()` function — should be split by category
-- `WOM.py` has a duplicate `get_rank()` that overlaps with `rank_utils._get_rank_for_ehb()`
-- Global state (`bot_state`, task handles) in `WOM.py` could be moved into a class
+- `python/config.ini` contains Discord/WOM credentials, channel IDs, feature flags, and intervals. New settings are `discord.gains_channel_id`, `settings.track_ehp`, `settings.gains_snapshot_interval`, `settings.gains_window_days`, and comma-separated `settings.gains_metrics`.
+- `python/ranks.ini` must contain `[Group Ranking]` for EHB. When EHP tracking is enabled it should also contain `[Skilling Ranking]`; copy `python/ranks.ini.example` for both ladders.
+- Gains defaults are a daily snapshot (`86400`) of a trailing 7-day window for `overall,ehb`. EHP tracking defaults off.
+- Docker mounts `config.ini` and `ranks.ini` read-only. CSV history can be redirected with `EHB_LOG_PATH`; SQLite can be redirected with `WOM_DATABASE_PATH`.
+
+## Testing notes
+
+- `tests/conftest.py` stubs optional runtime integrations and isolates rank/database paths.
+- `tests/test_rank_utils_ehp.py` covers dual EHB/EHP ranks, state preservation, missing sections, and next-rank behavior.
+- `tests/test_gains_snapshotter.py` covers pagination, metric resolution, leaderboard formatting, API failures, and atomic snapshots.
+- `tests/test_database.py` and `tests/test_web_routers.py` cover the new persistence and HTTP endpoints.
+
+## Known technical debt (from `rmap.md`)
+
+- `commands.py` still contains 20+ commands in one large `setup_commands()` function and should be split by category.
+- `WOM.py:get_rank()` is now only a compatibility wrapper over `rank_utils.get_rank_for_value()`; callers can eventually use the shared helper directly.
+- Global state (`bot_state`, task handles) in `WOM.py` could be moved into a class.
+- A monthly channel setting exists, but a monthly reporter is not implemented.

--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ A Discord bot that integrates with the Wise Old Man API to track EHB-based ranks
    ```
 
 Notes:
-- `weekly_channel_id` and `yearly_channel_id` enable scheduled report posts. Set to `0` to disable.
-- `monthly_channel_id` is currently unused; keep it at `0` if you are not using it.
+- `weekly_channel_id`, `monthly_channel_id`, and `yearly_channel_id` enable scheduled report posts. Set any channel to `0` to disable it. Monthly reports post at 12:00 UTC on the first day of each month.
 - `group_passcode` is only required for `/refreshgroup` (Wise Old Man update-all).
 - `api_key` is optional but helps with Wise Old Man rate limits.
 - EHP collection is opt-in. Set `track_ehp = true` to populate EHP ranks and history.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A Discord bot that integrates with the Wise Old Man API to track EHB-based ranks
    weekly_channel_id = 0
    yearly_channel_id = 0
    monthly_channel_id = 0
+   gains_channel_id = 0
 
    [wiseoldman]
    group_id = 1234
@@ -47,6 +48,10 @@ A Discord bot that integrates with the Wise Old Man API to track EHB-based ranks
    post_to_discord = true
    silent_mode = false
    debug = false
+   track_ehp = false
+   gains_snapshot_interval = 86400
+   gains_window_days = 7
+   gains_metrics = overall,ehb
    ```
 
 Notes:
@@ -54,9 +59,11 @@ Notes:
 - `monthly_channel_id` is currently unused; keep it at `0` if you are not using it.
 - `group_passcode` is only required for `/refreshgroup` (Wise Old Man update-all).
 - `api_key` is optional but helps with Wise Old Man rate limits.
+- EHP collection is opt-in. Set `track_ehp = true` to populate EHP ranks and history.
+- Gains snapshots default to a 7-day window collected daily. `gains_channel_id = 0` keeps the snapshots in SQLite without posting a Discord digest.
 - Keep your token/API values out of Git history.
 
-4. Create `python/ranks.ini` to define rank thresholds:
+4. Copy `python/ranks.ini.example` to `python/ranks.ini`, then adjust the rank thresholds if needed:
    ```ini
    [Group Ranking]
    0-10 = Goblin
@@ -69,7 +76,16 @@ Notes:
    750-1000 = Dragonstone
    1000-1500 = Onyx
    1500+ = Zenyte
+
+   [Skilling Ranking]
+   0-100 = Novice
+   100-500 = Apprentice
+   500-1000 = Adept
+   1000-1500 = Expert
+   1500+ = Master
    ```
+
+The skilling ladder is used for EHP when `track_ehp = true`.
 
 ## Run
 From the repo root:

--- a/python/WOM.py
+++ b/python/WOM.py
@@ -11,8 +11,22 @@ from typing import Optional
 from wom import Client as BaseClient
 
 from weeklyupdater import start_weekly_reporter, start_yearly_reporter
-from utils.database import count_players, import_csv_history, init_database, upsert_players
-from utils.rank_utils import load_ranks, save_ranks
+from gainstracker import start_gains_snapshotter
+from utils.database import (
+    count_players,
+    import_csv_history,
+    init_database,
+    upsert_players,
+    log_ehp_history,
+)
+from utils.rank_utils import (
+    load_ranks,
+    save_ranks,
+    get_rank_for_value,
+    get_ehp_rank,
+    compute_member_update,
+    EHB_SECTION,
+)
 from utils.log_csv import log_ehb_to_csv
 from utils.commands import setup_commands
 import uvicorn
@@ -81,6 +95,7 @@ discord_token       = config['discord']['token']
 channel_id          = int(config['discord']['channel_id'])
 weekly_channel_id   = int(config['discord'].get('weekly_channel_id', 0) or 0)
 yearly_channel_id   = int(config['discord'].get('yearly_channel_id', weekly_channel_id) or 0)
+gains_channel_id    = int(config['discord'].get('gains_channel_id', 0) or 0)
 group_id            = int(config['wiseoldman']['group_id'])
 group_passcode      = config['wiseoldman']['group_passcode']
 api_key             = config['wiseoldman'].get('api_key', '').strip() or None
@@ -91,6 +106,10 @@ print_csv_changes   = config['settings'].getboolean('print_csv_changes', True)
 post_to_discord     = config['settings'].getboolean('post_to_discord', True)
 silent              = config['settings'].getboolean('silent', False)
 debug               = config['settings'].getboolean('debug', False)
+track_ehp           = config['settings'].getboolean('track_ehp', False)
+gains_snapshot_interval = int(config['settings'].get('gains_snapshot_interval', 86400) or 86400)
+gains_window_days   = int(config['settings'].get('gains_window_days', 7) or 7)
+gains_metrics       = [m.strip() for m in config['settings'].get('gains_metrics', 'overall,ehb').split(',') if m.strip()]
 
 # Web interface settings
 web_enabled = config['web'].getboolean('enabled', False) if config.has_section('web') else False
@@ -126,6 +145,7 @@ wom_client = Client(api_key=api_key)
 
 weekly_report_task = None
 yearly_report_task = None
+gains_snapshot_task = None
 
 
 # Utility Functions
@@ -135,22 +155,10 @@ def get_rank(ehb, ranks_file=os.path.join(os.path.dirname(os.path.abspath(__file
     """
     Determines the rank based on the player's EHB using the ranges defined in ranks.ini.
     Ranges can be specified either as a range (e.g. "0-10") or as a lower bound (e.g. "1500+").
+
+    Thin wrapper over the consolidated ``rank_utils`` parser (single source of truth).
     """
-    try:
-        rank_config = configparser.ConfigParser()
-        rank_config.read(ranks_file)
-        for range_key, rank_name in rank_config['Group Ranking'].items():
-            if '+' in range_key:
-                lower_bound = int(range_key.replace('+', ''))
-                if ehb >= lower_bound:
-                    return rank_name
-            else:
-                lower_bound, upper_bound = map(int, range_key.split('-'))
-                if lower_bound <= ehb < upper_bound:
-                    return rank_name
-    except Exception as e:
-        log(f"Error reading ranks.ini: {e}")
-    return "Unknown"
+    return get_rank_for_value(ehb, EHB_SECTION, ranks_file)
 
 
 # Discord Events and Tasks
@@ -168,6 +176,25 @@ async def on_ready():
 
     global weekly_report_task
     global yearly_report_task
+    global gains_snapshot_task
+    if gains_snapshot_task is None:
+        if gains_channel_id or gains_metrics:
+            gains_snapshot_task = start_gains_snapshotter(
+                wom_client=wom_client,
+                discord_client=discord_client,
+                group_id=group_id,
+                channel_id=gains_channel_id,
+                metrics=gains_metrics,
+                window_days=gains_window_days,
+                interval_seconds=gains_snapshot_interval,
+                log=log,
+                on_snapshot=lambda: setattr(bot_state, "last_gains_snapshot", datetime.now()),
+                debug=debug,
+            )
+            log("Gains snapshot task started.")
+        else:
+            log("gains snapshot disabled (no metrics/channel configured).")
+
     if weekly_report_task is None:
         if weekly_channel_id:
             weekly_report_task = start_weekly_reporter(
@@ -235,31 +262,41 @@ async def check_for_rank_changes():
                     username = player.display_name
                     ehb = round(player.ehb, 2)
                     rank = get_rank(ehb)
-                    
 
-                    # Retrieve last known data
                     last_data = ranks_data.get(username, {})
-                    last_ehb = last_data.get("last_ehb", 0)
-                    last_rank = last_data.get("rank", "Unknown")
 
-                    # Compare and notify if rank has increased
-                    if ehb > last_ehb:
+                    ehp = None
+                    ehp_rank = None
+                    if track_ehp:
+                        ehp = round(getattr(player, "ehp", 0) or 0, 2)
+                        ehp_rank = get_ehp_rank(ehp)
+
+                    # Independent EHB / EHP evaluation merged into one entry.
+                    result = compute_member_update(
+                        last_data, ehb, rank, ehp=ehp, ehp_rank=ehp_rank, track_ehp=track_ehp
+                    )
+
+                    # --- EHB side effects ---
+                    if result["ehb_increase"]:
+                        last_ehb = last_data.get("last_ehb", 0)
                         log(f"Player {username} EHB increased from {last_ehb:.2f} to {ehb:.2f}")
-                        await send_rank_up_message(username, rank, last_rank, ehb)
+                        await send_rank_up_message(username, rank, result["ehb_old_rank"], ehb)
                         if debug:
                             log(f"Sent rank up message for {username} with {ehb} EHB for comparison in function.")
-
-                        # Update ranks data and log to CSV if enabled
-                        ranks_data[username] = {"last_ehb": ehb, "rank": rank}
                         if print_to_csv:
                             log_ehb_to_csv(username, ehb)
-                    elif rank != last_rank:
-                        # Rank label is stale (e.g. Unknown) but EHB hasn't changed — fix silently
-                        log(f"Correcting stale rank for {username}: '{last_rank}' -> '{rank}'")
-                        existing = ranks_data.get(username, {})
-                        existing["rank"] = rank
-                        ranks_data[username] = existing
+                    elif rank != result["ehb_old_rank"]:
+                        log(f"Correcting stale rank for {username}: '{result['ehb_old_rank']}' -> '{rank}'")
 
+                    # --- EHP side effects ---
+                    if track_ehp and result["ehp_increase"]:
+                        log(f"Player {username} EHP increased to {ehp:.2f}")
+                        await send_rank_up_message(
+                            username, ehp_rank, result["ehp_old_rank"], ehp, metric_label="EHP"
+                        )
+                        log_ehp_history(username, ehp)
+
+                    ranks_data[username] = result["entry"]
 
                 except Exception as e:
                     player_name = getattr(membership.player, "display_name", "Unknown")
@@ -372,7 +409,7 @@ async def refresh_group_task():
         if channel:
             await channel.send(msg)
 
-async def send_rank_up_message(username, new_rank, old_rank, ehb):
+async def send_rank_up_message(username, new_rank, old_rank, ehb, metric_label="EHB"):
     try:
         if debug:
             log(f"debug mode: Sending rank up message for {username}.")
@@ -382,9 +419,9 @@ async def send_rank_up_message(username, new_rank, old_rank, ehb):
             channel = get_messageable_channel(channel_id)
             if channel:
                 if post_to_discord:
-                    await channel.send(  
+                    await channel.send(
                         f'🎉 Congratulations **{username}** on moving up to the rank of **{new_rank}** '
-                        f'with **{ehb}** EHB! 🎉'
+                        f'with **{ehb}** {metric_label}! 🎉'
                     )
                     log(f"Sent rank up message for {username} to channel: {channel}")
             else:

--- a/python/WOM.py
+++ b/python/WOM.py
@@ -10,7 +10,7 @@ import contextlib
 from typing import Optional
 from wom import Client as BaseClient
 
-from weeklyupdater import start_weekly_reporter, start_yearly_reporter
+from weeklyupdater import start_monthly_reporter, start_weekly_reporter, start_yearly_reporter
 from gainstracker import start_gains_snapshotter
 from utils.database import (
     count_players,
@@ -94,6 +94,7 @@ config.read(config_file)
 discord_token       = config['discord']['token']
 channel_id          = int(config['discord']['channel_id'])
 weekly_channel_id   = int(config['discord'].get('weekly_channel_id', 0) or 0)
+monthly_channel_id  = int(config['discord'].get('monthly_channel_id', weekly_channel_id) or 0)
 yearly_channel_id   = int(config['discord'].get('yearly_channel_id', weekly_channel_id) or 0)
 gains_channel_id    = int(config['discord'].get('gains_channel_id', 0) or 0)
 group_id            = int(config['wiseoldman']['group_id'])
@@ -144,6 +145,7 @@ discord_client = IPv4Bot(command_prefix=commands.when_mentioned, intents=intents
 wom_client = Client(api_key=api_key)
 
 weekly_report_task = None
+monthly_report_task = None
 yearly_report_task = None
 gains_snapshot_task = None
 
@@ -175,6 +177,7 @@ async def on_ready():
     await wom_client.start()
 
     global weekly_report_task
+    global monthly_report_task
     global yearly_report_task
     global gains_snapshot_task
     if gains_snapshot_task is None:
@@ -208,6 +211,20 @@ async def on_ready():
             log("Weekly report task started.")
         else:
             log("weekly_channel_id not configured; weekly report disabled.")
+
+    if monthly_report_task is None:
+        if monthly_channel_id:
+            monthly_report_task = start_monthly_reporter(
+                wom_client=wom_client,
+                discord_client=discord_client,
+                group_id=group_id,
+                channel_id=monthly_channel_id,
+                log=log,
+                debug=debug,
+            )
+            log("Monthly report task started.")
+        else:
+            log("monthly_channel_id not configured; monthly report disabled.")
 
     if yearly_report_task is None:
         if yearly_channel_id:
@@ -452,6 +469,7 @@ setup_commands(
     wom_client,
     group_id,
     weekly_channel_id,
+    monthly_channel_id,
     yearly_channel_id,
     get_rank,
     list_all_members_and_ranks,

--- a/python/gainstracker/__init__.py
+++ b/python/gainstracker/__init__.py
@@ -1,0 +1,17 @@
+"""Persisted gains-snapshot tracking (Feature 4)."""
+
+from .gains_snapshotter import (
+    build_gains_lines,
+    collect_gains_leaderboard,
+    resolve_metric,
+    snapshot_gains_once,
+    start_gains_snapshotter,
+)
+
+__all__ = [
+    "build_gains_lines",
+    "collect_gains_leaderboard",
+    "resolve_metric",
+    "snapshot_gains_once",
+    "start_gains_snapshotter",
+]

--- a/python/gainstracker/gains_snapshotter.py
+++ b/python/gainstracker/gains_snapshotter.py
@@ -1,0 +1,239 @@
+"""Persisted gains-snapshot collector and scheduler (Feature 4).
+
+Unlike ``ehb_history`` (written only on EHB increase, EHB-only, sparse), this
+module stores dense trailing-window gains snapshots straight from the Wise Old
+Man gains API so the dashboard can chart per-metric moving averages.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+import typing as t
+
+from wom import enums
+
+from utils.database import log_gains_snapshot, read_latest_gains
+
+_TS_FMT = "%Y-%m-%d %H:%M:%S"
+
+
+def resolve_metric(name: str) -> t.Optional[enums.Metric]:
+    """Resolve a metric name (e.g. ``"overall"``, ``"ehb"``) to a ``Metric`` enum."""
+    if not name:
+        return None
+    candidate = name.strip().lower()
+    for metric in enums.Metric:
+        if getattr(metric, "value", metric) == candidate:
+            return metric
+    # Fall back to matching the enum member name (e.g. "Overall").
+    for metric in enums.Metric:
+        if metric.name.lower() == candidate.replace("_", ""):
+            return metric
+    return None
+
+
+async def _collect_gains(
+    wom_client,
+    group_id: int,
+    metric: enums.Metric,
+    start_date: datetime,
+    end_date: datetime,
+    *,
+    page_size: int = 50,
+) -> list:
+    """Paginate ``get_gains`` over ``offset`` so groups larger than 50 aren't truncated."""
+    entries: list = []
+    offset = 0
+    while True:
+        result = await wom_client.groups.get_gains(
+            group_id,
+            metric,
+            start_date=start_date,
+            end_date=end_date,
+            limit=page_size,
+            offset=offset,
+        )
+        if not result.is_ok:
+            break
+        page = list(result.unwrap())
+        if not page:
+            break
+        entries.extend(page)
+        if len(page) < page_size:
+            break
+        offset += page_size
+    return entries
+
+
+def _build_gains_rows(
+    entries: list,
+    *,
+    snapshot_time: str,
+    period_start: str,
+    period_end: str,
+    metric: str,
+) -> list[dict]:
+    """Turn gains API entries into persistable rows (pure)."""
+    rows: list[dict] = []
+    for entry in entries:
+        name = getattr(getattr(entry, "player", None), "display_name", None)
+        if not name:
+            continue
+        gained = getattr(getattr(entry, "data", None), "gained", 0) or 0
+        rows.append(
+            {
+                "snapshot_time": snapshot_time,
+                "period_start": period_start,
+                "period_end": period_end,
+                "username": name,
+                "metric": metric,
+                "gained": float(gained),
+            }
+        )
+    return rows
+
+
+async def snapshot_gains_once(
+    *,
+    wom_client,
+    group_id: int,
+    metrics: list[str],
+    window_days: int,
+    log,
+    now: t.Optional[datetime] = None,
+) -> int:
+    """Fetch and persist a trailing-window gains snapshot for each metric.
+
+    Returns the number of newly inserted rows across all metrics.
+    """
+    now = now or datetime.now(timezone.utc)
+    period_start = now - timedelta(days=window_days)
+    snapshot_str = now.strftime(_TS_FMT)
+    start_str = period_start.strftime(_TS_FMT)
+
+    inserted = 0
+    for metric_name in metrics:
+        metric = resolve_metric(metric_name)
+        if metric is None:
+            log(f"Gains snapshot: unknown metric '{metric_name}', skipping.")
+            continue
+        entries = await _collect_gains(wom_client, group_id, metric, period_start, now)
+        rows = _build_gains_rows(
+            entries,
+            snapshot_time=snapshot_str,
+            period_start=start_str,
+            period_end=snapshot_str,
+            metric=metric.value,
+        )
+        inserted += log_gains_snapshot(rows)
+    return inserted
+
+
+async def collect_gains_leaderboard(
+    *,
+    wom_client,
+    group_id: int,
+    metric_name: str,
+    window_days: int,
+    log,
+    now: t.Optional[datetime] = None,
+    limit: int = 15,
+) -> list[tuple[str, float]]:
+    """Compute a live (unpersisted) gains leaderboard for the ``/gains`` command."""
+    metric = resolve_metric(metric_name)
+    if metric is None:
+        return []
+    now = now or datetime.now(timezone.utc)
+    period_start = now - timedelta(days=window_days)
+    entries = await _collect_gains(wom_client, group_id, metric, period_start, now)
+    ranked = [
+        (getattr(entry.player, "display_name", "Unknown"), float(getattr(entry.data, "gained", 0) or 0))
+        for entry in entries
+    ]
+    ranked.sort(key=lambda item: item[1], reverse=True)
+    return ranked[:limit]
+
+
+def build_gains_lines(metric_name: str, window_days: int, leaderboard: list[tuple[str, float]]) -> list[str]:
+    """Render a gains leaderboard as code-block table lines (pure)."""
+    header = f"Top {metric_name} gains (last {window_days}d)"
+    lines = [header, f"{'#':<4}{'Player':<20}{'Gained':<15}", "-" * 40]
+    if not leaderboard:
+        lines.append("No gains data available.")
+        return lines
+    for index, (name, gained) in enumerate(leaderboard, start=1):
+        lines.append(f"{index:<4}{name:<20}{gained:>12,.0f}")
+    return lines
+
+
+async def _gains_snapshot_loop(
+    *,
+    wom_client,
+    discord_client,
+    group_id: int,
+    channel_id: int,
+    metrics: list[str],
+    window_days: int,
+    interval_seconds: int,
+    log,
+    on_snapshot=None,
+    debug: bool = False,
+) -> None:
+    while True:
+        try:
+            inserted = await snapshot_gains_once(
+                wom_client=wom_client,
+                group_id=group_id,
+                metrics=metrics,
+                window_days=window_days,
+                log=log,
+            )
+            if debug:
+                log(f"Gains snapshot stored {inserted} rows.")
+            if on_snapshot is not None:
+                on_snapshot()
+
+            if channel_id and metrics:
+                primary = metrics[0]
+                leaderboard = [
+                    (row["username"], row["gained"]) for row in read_latest_gains(primary, limit=15)
+                ]
+                lines = build_gains_lines(primary, window_days, leaderboard)
+                channel = discord_client.get_channel(channel_id)
+                if channel is not None:
+                    await channel.send("```\n" + "\n".join(lines) + "\n```")  # pyright: ignore[reportAttributeAccessIssue]
+        except Exception as e:  # noqa: BLE001 — a scheduler must not die on one bad cycle
+            log(f"Gains snapshot loop error: {e}")
+
+        await asyncio.sleep(max(interval_seconds, 60))
+
+
+def start_gains_snapshotter(
+    *,
+    wom_client,
+    discord_client,
+    group_id: int,
+    channel_id: int,
+    metrics: list[str],
+    window_days: int,
+    interval_seconds: int,
+    log,
+    on_snapshot=None,
+    debug: bool = False,
+) -> asyncio.Task:
+    """Start the daily gains-snapshot task (persists + optional Discord digest)."""
+    return asyncio.create_task(
+        _gains_snapshot_loop(
+            wom_client=wom_client,
+            discord_client=discord_client,
+            group_id=group_id,
+            channel_id=channel_id,
+            metrics=metrics,
+            window_days=window_days,
+            interval_seconds=interval_seconds,
+            log=log,
+            on_snapshot=on_snapshot,
+            debug=debug,
+        )
+    )

--- a/python/gainstracker/gains_snapshotter.py
+++ b/python/gainstracker/gains_snapshotter.py
@@ -39,35 +39,22 @@ async def _collect_gains(
     metric: enums.Metric,
     start_date: datetime,
     end_date: datetime,
-    *,
-    page_size: int = 50,
 ) -> list:
-    """Paginate ``get_gains`` over ``offset`` so groups larger than 50 aren't truncated."""
-    entries: list = []
-    offset = 0
-    while True:
-        result = await wom_client.groups.get_gains(
-            group_id,
-            metric,
-            start_date=start_date,
-            end_date=end_date,
-            limit=page_size,
-            offset=offset,
-        )
-        if not result.is_ok:
-            error = result.unwrap_err()
-            raise RuntimeError(
-                f"Failed to fetch gains for metric '{metric.value}' "
-                f"at offset {offset}: {error}"
-            )
-        page = list(result.unwrap())
-        if not page:
-            break
-        entries.extend(page)
-        if len(page) < page_size:
-            break
-        offset += page_size
-    return entries
+    """Fetch all group gains in one request.
+
+    WOM's group-gains endpoint does not support pagination and always returns the
+    full member list. Supplying an offset is ignored by the API.
+    """
+    result = await wom_client.groups.get_gains(
+        group_id,
+        metric,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    if not result.is_ok:
+        error = result.unwrap_err()
+        raise RuntimeError(f"Failed to fetch gains for metric '{metric.value}': {error}")
+    return list(result.unwrap())
 
 
 def _build_gains_rows(

--- a/python/gainstracker/gains_snapshotter.py
+++ b/python/gainstracker/gains_snapshotter.py
@@ -55,7 +55,11 @@ async def _collect_gains(
             offset=offset,
         )
         if not result.is_ok:
-            break
+            error = result.unwrap_err()
+            raise RuntimeError(
+                f"Failed to fetch gains for metric '{metric.value}' "
+                f"at offset {offset}: {error}"
+            )
         page = list(result.unwrap())
         if not page:
             break
@@ -112,22 +116,29 @@ async def snapshot_gains_once(
     snapshot_str = now.strftime(_TS_FMT)
     start_str = period_start.strftime(_TS_FMT)
 
-    inserted = 0
+    all_rows: list[dict] = []
+    valid_metrics = 0
     for metric_name in metrics:
         metric = resolve_metric(metric_name)
         if metric is None:
             log(f"Gains snapshot: unknown metric '{metric_name}', skipping.")
             continue
+        valid_metrics += 1
         entries = await _collect_gains(wom_client, group_id, metric, period_start, now)
-        rows = _build_gains_rows(
-            entries,
-            snapshot_time=snapshot_str,
-            period_start=start_str,
-            period_end=snapshot_str,
-            metric=metric.value,
+        all_rows.extend(
+            _build_gains_rows(
+                entries,
+                snapshot_time=snapshot_str,
+                period_start=start_str,
+                period_end=snapshot_str,
+                metric=metric.value,
+            )
         )
-        inserted += log_gains_snapshot(rows)
-    return inserted
+
+    if valid_metrics == 0:
+        raise ValueError("Gains snapshot has no valid metrics configured.")
+
+    return log_gains_snapshot(all_rows)
 
 
 async def collect_gains_leaderboard(

--- a/python/ranks.ini.example
+++ b/python/ranks.ini.example
@@ -1,0 +1,20 @@
+[Group Ranking]
+
+0-10 = Goblin
+10-50 = Opal
+50-120 = Sapphire
+120-250 = Emerald
+250-400 = Red Topaz
+400-550 = Ruby
+550-750 = Diamond
+750-1000 = Dragonstone
+1000-1500 = Onyx
+1500+ = Zenyte
+
+[Skilling Ranking]
+
+0-100 = Novice
+100-500 = Apprentice
+500-1000 = Adept
+1000-1500 = Expert
+1500+ = Master

--- a/python/utils/commands.py
+++ b/python/utils/commands.py
@@ -14,7 +14,13 @@ import aiohttp
 from discord import app_commands, Interaction
 from discord.ext import commands
 
-from .rank_utils import load_ranks, save_ranks, next_rank, next_rank_ehp
+from .rank_utils import (
+    load_ranks,
+    merge_manual_rank_update,
+    next_rank,
+    next_rank_ehp,
+    save_ranks,
+)
 from gainstracker import build_gains_lines, collect_gains_leaderboard, resolve_metric
 from weeklyupdater import (
     generate_weekly_report_messages,
@@ -154,10 +160,17 @@ def setup_commands(
                     rank = get_rank(ehb)
 
                     # Update ranks_data
-                    ranks_data[username] = {
-                        "last_ehb": ehb,
-                        "rank": rank,
-                    }
+                    rank_key = next(
+                        (
+                            stored_username
+                            for stored_username in ranks_data
+                            if stored_username.lower() == username.lower()
+                        ),
+                        username,
+                    )
+                    ranks_data[rank_key] = merge_manual_rank_update(
+                        ranks_data.get(rank_key, {}), ehb, rank
+                    )
                     save_ranks(ranks_data)
 
                     # Send formatted message to Discord

--- a/python/utils/commands.py
+++ b/python/utils/commands.py
@@ -23,10 +23,13 @@ from .rank_utils import (
 )
 from gainstracker import build_gains_lines, collect_gains_leaderboard, resolve_metric
 from weeklyupdater import (
+    generate_monthly_report_messages,
     generate_weekly_report_messages,
     generate_yearly_report_messages,
+    most_recent_month_end,
     most_recent_year_end,
     most_recent_week_end,
+    send_monthly_report,
     send_yearly_report,
     send_weekly_report,
     write_yearly_report_file,
@@ -58,6 +61,7 @@ def setup_commands(
     wom_client,
     GROUP_ID: int,
     weekly_channel_id: int,
+    monthly_channel_id: int,
     yearly_channel_id: int,
     get_rank,
     list_all_members_and_ranks,
@@ -240,6 +244,37 @@ def setup_commands(
                 f"❌ Error sending weekly report: {e}", ephemeral=True
             )
 
+    # Command: /monthlyreport --- Posts the monthly report to the monthly channel.
+
+    @bot.tree.command(name="monthlyreport", description="Posts the most recent completed monthly report.")
+    async def monthlyreport(interaction: Interaction):
+        if not monthly_channel_id:
+            await interaction.response.send_message(
+                "❌ monthly_channel_id not configured.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        try:
+            end_date = most_recent_month_end(datetime.now(timezone.utc))
+            messages = await generate_monthly_report_messages(
+                wom_client=wom_client,
+                group_id=GROUP_ID,
+                end_date=end_date,
+                log=log,
+            )
+            await send_monthly_report(
+                discord_client=bot,
+                channel_id=monthly_channel_id,
+                messages=messages,
+                log=log,
+            )
+            await interaction.followup.send("✅ Monthly report sent.", ephemeral=True)
+        except Exception as e:
+            await interaction.followup.send(
+                f"❌ Error sending monthly report: {e}", ephemeral=True
+            )
+
     # Command: /yearlyreport --- Posts the yearly report to the yearly channel.
 
     @bot.tree.command(name="yearlyreport", description="Posts the yearly report to the yearly channel.")
@@ -360,6 +395,7 @@ def setup_commands(
             "/goodnight ➡️  Sends a good night message.",
             "/forcecheck ➡️     Forces check_for_rank_changes task to run.",
             "/weeklyupdate ➡️   Posts the weekly report to the weekly channel.",
+            "/monthlyreport ➡️   Posts the last completed monthly report.",
             "/yearlyreport [year] ➡️   Posts the yearly report to the yearly channel.",
             "/yearlyreportfile [year] [filename] ➡️   Writes the yearly report to a local file.",
             "/sendrankup_debug ➡️   Debugging command to simulate a rank up message.",

--- a/python/utils/commands.py
+++ b/python/utils/commands.py
@@ -14,7 +14,8 @@ import aiohttp
 from discord import app_commands, Interaction
 from discord.ext import commands
 
-from .rank_utils import load_ranks, save_ranks, next_rank
+from .rank_utils import load_ranks, save_ranks, next_rank, next_rank_ehp
+from gainstracker import build_gains_lines, collect_gains_leaderboard, resolve_metric
 from weeklyupdater import (
     generate_weekly_report_messages,
     generate_yearly_report_messages,
@@ -24,6 +25,26 @@ from weeklyupdater import (
     send_weekly_report,
     write_yearly_report_file,
 )
+
+
+def _chunk_code_block(lines: list[str], limit: int = 1990) -> list[str]:
+    """Wrap table lines in ``` code blocks, splitting to stay under Discord's cap."""
+    messages: list[str] = []
+    current: list[str] = []
+
+    def flush() -> None:
+        if current:
+            messages.append("```\n" + "\n".join(current) + "\n```")
+
+    for line in lines:
+        tentative = "\n".join(current + [line])
+        if len(tentative) + 8 > limit and current:
+            flush()
+            current.clear()
+        current.append(line)
+    flush()
+
+    return messages or ["```\n(no data)\n```"]
 
 
 def setup_commands(
@@ -50,11 +71,15 @@ def setup_commands(
         try:
             ranks_data = load_ranks()
             if username in ranks_data:
-                ehb = ranks_data[username]["last_ehb"]
-                rank = ranks_data[username]["rank"]
-                await interaction.response.send_message(
-                    f"**{username}**\n**Rank:** {rank} ({ehb} EHB)"
-                )
+                user_data = ranks_data[username]
+                ehb = user_data["last_ehb"]
+                rank = user_data["rank"]
+                message = f"**{username}**\n**Rank:** {rank} ({ehb} EHB)"
+                if "ehp_rank" in user_data:
+                    ehp = user_data.get("last_ehp", 0)
+                    ehp_rank = user_data.get("ehp_rank", "Unknown")
+                    message += f"\n**Skilling Rank:** {ehp_rank} ({ehp} EHP)"
+                await interaction.response.send_message(message)
                 if debug:
                     print(f"Listed {username}: {rank} ({ehb} EHB)")
             else:
@@ -409,14 +434,104 @@ def setup_commands(
             current_ehb = user_data.get("last_ehb", 0)
             next_rank_info = next_rank(username)
 
-            await interaction.response.send_message(
+            message = (
                 f"🔹 **Player:** {username}\n"
                 f"🏅 **Current Rank:** {current_rank} ({current_ehb} EHB)\n"
                 f"📈 **Next Rank:** {next_rank_info}"
             )
+            if "ehp_rank" in user_data:
+                current_ehp_rank = user_data.get("ehp_rank", "Unknown")
+                current_ehp = user_data.get("last_ehp", 0)
+                message += (
+                    f"\n⛏️ **Current Skilling Rank:** {current_ehp_rank} ({current_ehp} EHP)\n"
+                    f"📈 **Next Skilling Rank:** {next_rank_ehp(username)}"
+                )
+            await interaction.response.send_message(message)
         except Exception as e:
             await interaction.response.send_message(
                 f"❌ An error occurred: {e}", ephemeral=True
             )
             if debug:
                 print(f"Error in /rankup command: {e}")
+
+    # Command: /ehpladder --- Lists players ranked by EHP (skilling).
+
+    @bot.tree.command(
+        name="ehpladder",
+        description="Lists players ranked by EHP (skilling efficiency).",
+    )
+    async def ehpladder(interaction: Interaction):
+        try:
+            ranks_data = load_ranks()
+            players = [
+                (
+                    username,
+                    data.get("ehp_rank", "Unknown"),
+                    round(float(data.get("last_ehp", 0) or 0), 2),
+                )
+                for username, data in ranks_data.items()
+            ]
+            players = [entry for entry in players if entry[2] > 0]
+            players.sort(key=lambda entry: entry[2], reverse=True)
+
+            if not players:
+                await interaction.response.send_message(
+                    "❌ No EHP data available yet. Enable `track_ehp` and let the bot run a check.",
+                    ephemeral=True,
+                )
+                return
+
+            lines = [f"{'#':<4}{'Player':<20}{'Skill Rank':<15}{'EHP':<10}", "-" * 50]
+            for index, (username, ehp_rank, ehp) in enumerate(players, start=1):
+                lines.append(f"{index:<4}{username:<20}{ehp_rank:<15}{ehp:<10}")
+
+            messages = _chunk_code_block(lines)
+            await interaction.response.send_message(messages[0])
+            for extra in messages[1:]:
+                await interaction.followup.send(extra)
+        except Exception as e:
+            await interaction.response.send_message(
+                f"❌ An error occurred: {e}", ephemeral=True
+            )
+            if debug:
+                print(f"Error in /ehpladder command: {e}")
+
+    # Command: /gains --- Live leaderboard of gains for a metric over a period.
+
+    @bot.tree.command(
+        name="gains",
+        description="Shows the top gainers for a metric over the last N days.",
+    )
+    @app_commands.describe(
+        metric="Metric name (e.g. overall, ehb, sailing, zulrah).",
+        days="Look-back window in days (default 7).",
+    )
+    async def gains(interaction: Interaction, metric: str, days: Optional[int] = 7):
+        window_days = days if days and days > 0 else 7
+        if resolve_metric(metric) is None:
+            await interaction.response.send_message(
+                f"❌ Unknown metric '{metric}'. Try `overall`, `ehb`, `sailing`, or a boss name.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.defer()
+        try:
+            await wom_client.start()
+            leaderboard = await collect_gains_leaderboard(
+                wom_client=wom_client,
+                group_id=GROUP_ID,
+                metric_name=metric,
+                window_days=window_days,
+                log=log,
+            )
+            lines = build_gains_lines(metric, window_days, leaderboard)
+            messages = _chunk_code_block(lines)
+            for message in messages:
+                await interaction.followup.send(message)
+        except Exception as e:
+            await interaction.followup.send(
+                f"❌ Error fetching gains: {e}", ephemeral=True
+            )
+            if debug:
+                print(f"Error in /gains command: {e}")

--- a/python/utils/database.py
+++ b/python/utils/database.py
@@ -6,7 +6,7 @@ import csv
 import os
 import sqlite3
 from contextlib import closing
-from datetime import datetime
+from datetime import datetime, timezone
 
 DEFAULT_DB_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "database.db")
 
@@ -14,6 +14,19 @@ DEFAULT_DB_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..",
 def resolve_db_path() -> str:
     """Return the configured SQLite database path."""
     return os.environ.get("WOM_DATABASE_PATH", DEFAULT_DB_FILE)
+
+
+def _ensure_columns(conn: sqlite3.Connection, table: str, columns: dict[str, str]) -> None:
+    """Idempotently add missing columns to an existing table.
+
+    ``CREATE TABLE IF NOT EXISTS`` is a no-op on an already-deployed database, so
+    it never adds new columns. This helper inspects the live schema and issues
+    ``ALTER TABLE ... ADD COLUMN`` only for columns that are not present yet.
+    """
+    existing = {row["name"] for row in conn.execute(f"PRAGMA table_info({table})")}
+    for name, ddl in columns.items():
+        if name not in existing:
+            conn.execute(f"ALTER TABLE {table} ADD COLUMN {name} {ddl}")
 
 
 def connect_db(db_path: str | None = None) -> sqlite3.Connection:
@@ -64,13 +77,91 @@ def init_database(db_path: str | None = None) -> str:
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_ehb_history_username_ts ON ehb_history (username, timestamp)"
         )
+
+        # Feature 2 (EHP) + Feature 3 (inactivity/status) add columns to the
+        # existing ``players`` table. On a fresh database the CREATE above does
+        # not include them, and on a deployed database the CREATE is a no-op, so
+        # the migration helper is the single source of truth for these columns.
+        _ensure_columns(
+            conn,
+            "players",
+            {
+                # Feature 2 — skilling (EHP) rank ladder
+                "last_ehp": "REAL NOT NULL DEFAULT 0",
+                "ehp_rank": "TEXT NOT NULL DEFAULT 'Unknown'",
+                # Feature 3 — inactivity / status detection
+                "player_id": "INTEGER",
+                "wom_status": "TEXT",
+                "last_changed_at": "TEXT",
+                "wom_updated_at": "TEXT",
+                "last_progressed_at": "TEXT",
+                "status_captured_at": "TEXT",
+            },
+        )
+
+        # Feature 2 — EHP history (mirror of ehb_history)
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS ehp_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                username TEXT NOT NULL,
+                ehp REAL NOT NULL,
+                UNIQUE(timestamp, username, ehp)
+            )
+            """
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_ehp_history_username_ts ON ehp_history (username, timestamp)"
+        )
+
+        # Feature 1 — per-boss leaderboards / kill history
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS boss_kills_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                boss TEXT NOT NULL,
+                username TEXT NOT NULL,
+                kills INTEGER NOT NULL,
+                rank INTEGER,
+                UNIQUE(timestamp, boss, username)
+            )
+            """
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_boss_kills_boss_ts ON boss_kills_history (boss, timestamp)"
+        )
+
+        # Feature 4 — persisted gains snapshots
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS gains_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                snapshot_time TEXT NOT NULL,
+                period_start TEXT NOT NULL,
+                period_end TEXT NOT NULL,
+                username TEXT NOT NULL,
+                metric TEXT NOT NULL,
+                gained REAL NOT NULL,
+                UNIQUE(snapshot_time, username, metric)
+            )
+            """
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_gains_metric_ts ON gains_history (metric, snapshot_time)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_gains_user_metric_ts ON gains_history (username, metric, snapshot_time)"
+        )
+
         conn.commit()
 
     return resolved_path
 
 
 def upsert_players(players: dict[str, dict], db_path: str | None = None) -> None:
-    """Persist the latest player snapshot to SQLite."""
+    """Persist the latest player rank snapshot (EHB + EHP) to SQLite."""
     if not players:
         return
 
@@ -79,11 +170,13 @@ def upsert_players(players: dict[str, dict], db_path: str | None = None) -> None
     with closing(connect_db(resolved_path)) as conn:
         conn.executemany(
             """
-            INSERT INTO players (username, last_ehb, rank, updated_at)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO players (username, last_ehb, rank, last_ehp, ehp_rank, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
             ON CONFLICT(username) DO UPDATE SET
                 last_ehb = excluded.last_ehb,
                 rank = excluded.rank,
+                last_ehp = excluded.last_ehp,
+                ehp_rank = excluded.ehp_rank,
                 updated_at = excluded.updated_at
             """,
             [
@@ -91,12 +184,77 @@ def upsert_players(players: dict[str, dict], db_path: str | None = None) -> None
                     username,
                     float(data.get("last_ehb", 0)),
                     str(data.get("rank", "Unknown")),
+                    float(data.get("last_ehp", 0)),
+                    str(data.get("ehp_rank", "Unknown")),
                     timestamp,
                 )
                 for username, data in players.items()
             ],
         )
         conn.commit()
+
+
+def upsert_player_status(rows: list[dict], db_path: str | None = None) -> None:
+    """Persist per-player WOM status/activity metadata (Feature 3).
+
+    Touches only the status/activity columns so it can be called independently of
+    :func:`upsert_players` without clobbering the rank snapshot.
+    """
+    if not rows:
+        return
+
+    resolved_path = init_database(db_path)
+    captured_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    with closing(connect_db(resolved_path)) as conn:
+        conn.executemany(
+            """
+            INSERT INTO players (
+                username, player_id, wom_status, last_changed_at,
+                wom_updated_at, last_progressed_at, status_captured_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(username) DO UPDATE SET
+                player_id = excluded.player_id,
+                wom_status = excluded.wom_status,
+                last_changed_at = excluded.last_changed_at,
+                wom_updated_at = excluded.wom_updated_at,
+                last_progressed_at = excluded.last_progressed_at,
+                status_captured_at = excluded.status_captured_at
+            """,
+            [
+                (
+                    str(row.get("username")),
+                    row.get("player_id"),
+                    row.get("wom_status"),
+                    row.get("last_changed_at"),
+                    row.get("wom_updated_at"),
+                    row.get("last_progressed_at"),
+                    captured_at,
+                    captured_at,
+                )
+                for row in rows
+                if row.get("username")
+            ],
+        )
+        conn.commit()
+
+
+def read_player_status_rows(db_path: str | None = None) -> list[dict]:
+    """Return persisted per-player status/activity rows (Feature 3).
+
+    Threshold classification (inactivity, fallback chain, timezone handling) is
+    performed by :mod:`utils.inactivity`; this reader only surfaces the raw rows.
+    """
+    resolved_path = init_database(db_path)
+    with closing(connect_db(resolved_path)) as conn:
+        rows = conn.execute(
+            """
+            SELECT username, last_ehb, rank, player_id, wom_status,
+                   last_changed_at, wom_updated_at, last_progressed_at, status_captured_at
+            FROM players
+            """
+        ).fetchall()
+    return [dict(row) for row in rows]
 
 
 def log_ehb_history(username: str, ehb: float, timestamp: str | None = None, db_path: str | None = None) -> None:
@@ -112,6 +270,209 @@ def log_ehb_history(username: str, ehb: float, timestamp: str | None = None, db_
             (recorded_at, username, float(ehb)),
         )
         conn.commit()
+
+
+def log_ehp_history(username: str, ehp: float, timestamp: str | None = None, db_path: str | None = None) -> None:
+    """Insert one EHP history row into SQLite (Feature 2)."""
+    resolved_path = init_database(db_path)
+    recorded_at = timestamp or datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+    with closing(connect_db(resolved_path)) as conn:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO ehp_history (timestamp, username, ehp)
+            VALUES (?, ?, ?)
+            """,
+            (recorded_at, username, float(ehp)),
+        )
+        conn.commit()
+
+
+def read_player_ehp_history(username: str, db_path: str | None = None) -> list[dict]:
+    """Return ``[{timestamp, ehp}]`` for a player, ordered by time (Feature 2)."""
+    resolved_path = init_database(db_path)
+    with closing(connect_db(resolved_path)) as conn:
+        rows = conn.execute(
+            """
+            SELECT timestamp, ehp FROM ehp_history
+            WHERE username = ? COLLATE NOCASE
+            ORDER BY timestamp
+            """,
+            (username,),
+        ).fetchall()
+    return [{"timestamp": row["timestamp"], "ehp": row["ehp"]} for row in rows]
+
+
+# ---------------------------------------------------------------------------
+# Feature 1 — per-boss leaderboards / kill history
+# ---------------------------------------------------------------------------
+
+
+def log_boss_kills(boss: str, rows: list[dict], timestamp: str | None = None, db_path: str | None = None) -> None:
+    """Persist a boss-kill leaderboard snapshot.
+
+    ``rows`` is a list of ``{username, kills, rank}`` dicts. The ``UNIQUE`` index
+    on ``(timestamp, boss, username)`` makes repeated writes of the same snapshot
+    idempotent.
+    """
+    if not rows:
+        return
+
+    resolved_path = init_database(db_path)
+    recorded_at = timestamp or datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    with closing(connect_db(resolved_path)) as conn:
+        conn.executemany(
+            """
+            INSERT OR IGNORE INTO boss_kills_history (timestamp, boss, username, kills, rank)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    recorded_at,
+                    boss,
+                    str(row.get("username")),
+                    int(row.get("kills", 0)),
+                    row.get("rank"),
+                )
+                for row in rows
+                if row.get("username")
+            ],
+        )
+        conn.commit()
+
+
+def get_boss_leaderboard(boss: str, db_path: str | None = None) -> list[dict]:
+    """Return the latest stored leaderboard for ``boss`` (kills descending)."""
+    resolved_path = init_database(db_path)
+    with closing(connect_db(resolved_path)) as conn:
+        latest = conn.execute(
+            "SELECT MAX(timestamp) AS ts FROM boss_kills_history WHERE boss = ?",
+            (boss,),
+        ).fetchone()
+        if not latest or latest["ts"] is None:
+            return []
+        rows = conn.execute(
+            """
+            SELECT username, kills, rank, timestamp
+            FROM boss_kills_history
+            WHERE boss = ? AND timestamp = ?
+            ORDER BY kills DESC, username
+            """,
+            (boss, latest["ts"]),
+        ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def get_boss_history(boss: str, username: str, db_path: str | None = None) -> list[dict]:
+    """Return ``[{timestamp, kills}]`` history for one player at one boss."""
+    resolved_path = init_database(db_path)
+    with closing(connect_db(resolved_path)) as conn:
+        rows = conn.execute(
+            """
+            SELECT timestamp, kills FROM boss_kills_history
+            WHERE boss = ? AND username = ? COLLATE NOCASE
+            ORDER BY timestamp
+            """,
+            (boss, username),
+        ).fetchall()
+    return [{"timestamp": row["timestamp"], "kills": row["kills"]} for row in rows]
+
+
+def list_tracked_bosses(db_path: str | None = None) -> list[str]:
+    """Return the distinct bosses that have stored kill snapshots."""
+    resolved_path = init_database(db_path)
+    with closing(connect_db(resolved_path)) as conn:
+        rows = conn.execute(
+            "SELECT DISTINCT boss FROM boss_kills_history ORDER BY boss"
+        ).fetchall()
+    return [row["boss"] for row in rows]
+
+
+# ---------------------------------------------------------------------------
+# Feature 4 — persisted gains snapshots
+# ---------------------------------------------------------------------------
+
+
+def log_gains_snapshot(rows: list[dict], db_path: str | None = None) -> int:
+    """Persist gains-snapshot rows.
+
+    ``rows`` is a list of ``{snapshot_time, period_start, period_end, username,
+    metric, gained}`` dicts. Returns the number of newly inserted rows.
+    """
+    if not rows:
+        return 0
+
+    resolved_path = init_database(db_path)
+    inserted = 0
+    with closing(connect_db(resolved_path)) as conn:
+        for row in rows:
+            if not row.get("username"):
+                continue
+            cursor = conn.execute(
+                """
+                INSERT OR IGNORE INTO gains_history
+                    (snapshot_time, period_start, period_end, username, metric, gained)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    row.get("snapshot_time"),
+                    row.get("period_start"),
+                    row.get("period_end"),
+                    str(row.get("username")),
+                    str(row.get("metric")),
+                    float(row.get("gained", 0)),
+                ),
+            )
+            inserted += cursor.rowcount
+        conn.commit()
+    return inserted
+
+
+def list_gains_metrics(db_path: str | None = None) -> list[str]:
+    """Return the distinct metrics that have stored gains snapshots."""
+    resolved_path = init_database(db_path)
+    with closing(connect_db(resolved_path)) as conn:
+        rows = conn.execute(
+            "SELECT DISTINCT metric FROM gains_history ORDER BY metric"
+        ).fetchall()
+    return [row["metric"] for row in rows]
+
+
+def read_gains_history(username: str, metric: str, db_path: str | None = None) -> list[dict]:
+    """Return ``[{snapshot_time, gained}]`` for a player+metric, ordered by time."""
+    resolved_path = init_database(db_path)
+    with closing(connect_db(resolved_path)) as conn:
+        rows = conn.execute(
+            """
+            SELECT snapshot_time, gained FROM gains_history
+            WHERE username = ? COLLATE NOCASE AND metric = ?
+            ORDER BY snapshot_time
+            """,
+            (username, metric),
+        ).fetchall()
+    return [{"timestamp": row["snapshot_time"], "gained": row["gained"]} for row in rows]
+
+
+def read_latest_gains(metric: str, limit: int = 20, db_path: str | None = None) -> list[dict]:
+    """Return the most recent snapshot's leaderboard for ``metric`` (gained desc)."""
+    resolved_path = init_database(db_path)
+    with closing(connect_db(resolved_path)) as conn:
+        latest = conn.execute(
+            "SELECT MAX(snapshot_time) AS ts FROM gains_history WHERE metric = ?",
+            (metric,),
+        ).fetchone()
+        if not latest or latest["ts"] is None:
+            return []
+        rows = conn.execute(
+            """
+            SELECT username, gained, snapshot_time, period_start, period_end
+            FROM gains_history
+            WHERE metric = ? AND snapshot_time = ?
+            ORDER BY gained DESC, username
+            LIMIT ?
+            """,
+            (metric, latest["ts"], limit),
+        ).fetchall()
+    return [dict(row) for row in rows]
 
 
 def import_csv_history(db_path: str | None = None, file_name: str = "ehb_log.csv") -> int:

--- a/python/utils/database.py
+++ b/python/utils/database.py
@@ -4,11 +4,24 @@ from __future__ import annotations
 
 import csv
 import os
+import re
 import sqlite3
 from contextlib import closing
 from datetime import datetime, timezone
 
 DEFAULT_DB_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "database.db")
+
+# SQLite cannot bind table/column names as parameters, so identifiers used in
+# DDL are interpolated directly. Restrict them to a safe character set so the
+# f-strings below can never carry injected SQL, even if a caller is changed.
+_SQL_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _assert_identifier(value: str) -> str:
+    """Return ``value`` if it is a safe SQL identifier, else raise ``ValueError``."""
+    if not _SQL_IDENTIFIER.match(value):
+        raise ValueError(f"Unsafe SQL identifier: {value!r}")
+    return value
 
 
 def resolve_db_path() -> str:
@@ -23,9 +36,13 @@ def _ensure_columns(conn: sqlite3.Connection, table: str, columns: dict[str, str
     it never adds new columns. This helper inspects the live schema and issues
     ``ALTER TABLE ... ADD COLUMN`` only for columns that are not present yet.
     """
+    _assert_identifier(table)
+    # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query,python.lang.security.audit.formatted-sql-query.formatted-sql-query -- identifier validated above; PRAGMA cannot use bound parameters
     existing = {row["name"] for row in conn.execute(f"PRAGMA table_info({table})")}
     for name, ddl in columns.items():
         if name not in existing:
+            _assert_identifier(name)
+            # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query,python.lang.security.audit.formatted-sql-query.formatted-sql-query -- table/column validated; ALTER TABLE cannot use bound parameters
             conn.execute(f"ALTER TABLE {table} ADD COLUMN {name} {ddl}")
 
 

--- a/python/utils/rank_utils.py
+++ b/python/utils/rank_utils.py
@@ -6,27 +6,65 @@ from .log_csv import load_latest_ehb_from_csv
 
 # JSON file for storing player ranks
 RANKS_FILE = os.path.join(os.path.dirname(__file__), 'player_ranks.json')
+RANKS_INI = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'ranks.ini')
+
+# Section names inside ranks.ini for each tracked metric.
+EHB_SECTION = "Group Ranking"
+EHP_SECTION = "Skilling Ranking"
+
 _BOOTSTRAPPED_FROM_CSV = False
 
 
-def _get_rank_for_ehb(ehb):
-    """Return rank name for an EHB value using ranks.ini thresholds."""
-    ranks_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'ranks.ini')
+def get_rank_thresholds(section=EHB_SECTION, ranks_file=None):
+    """Return sorted ``[(lower, upper_or_None, rank_name), ...]`` for a ranks.ini section.
+
+    A ``"1500+"`` key becomes ``(1500, None, name)`` (open-ended); a ``"10-50"``
+    key becomes ``(10, 50, name)``. Results are sorted by lower bound. Unknown
+    sections return an empty list.
+    """
+    config = configparser.ConfigParser()
+    config.read(ranks_file or RANKS_INI)
+    if not config.has_section(section):
+        return []
+
+    thresholds = []
+    for range_key, rank_name in config[section].items():
+        if '+' in range_key:
+            lower_bound = int(range_key.replace('+', ''))
+            thresholds.append((lower_bound, None, rank_name))
+        else:
+            lower_bound, upper_bound = map(int, range_key.split('-'))
+            thresholds.append((lower_bound, upper_bound, rank_name))
+    thresholds.sort(key=lambda item: item[0])
+    return thresholds
+
+
+def get_rank_for_value(value, section=EHB_SECTION, ranks_file=None):
+    """Return the rank name for ``value`` using the given ranks.ini section.
+
+    Boundary semantics: ``lower <= value < upper`` for ranges, ``value >= lower``
+    for open-ended ``"+"`` tiers. Falls back to ``"Unknown"``.
+    """
     try:
-        rank_config = configparser.ConfigParser()
-        rank_config.read(ranks_path)
-        for range_key, rank_name in rank_config['Group Ranking'].items():
-            if '+' in range_key:
-                lower_bound = int(range_key.replace('+', ''))
-                if ehb >= lower_bound:
+        for lower_bound, upper_bound, rank_name in get_rank_thresholds(section, ranks_file):
+            if upper_bound is None:
+                if value >= lower_bound:
                     return rank_name
-            else:
-                lower_bound, upper_bound = map(int, range_key.split('-'))
-                if lower_bound <= ehb < upper_bound:
-                    return rank_name
+            elif lower_bound <= value < upper_bound:
+                return rank_name
     except Exception as e:
-        print(f"Error reading ranks.ini for CSV bootstrap: {e}")
+        print(f"Error reading ranks.ini: {e}")
     return "Unknown"
+
+
+def _get_rank_for_ehb(ehb, ranks_file=None):
+    """Return rank name for an EHB value using ranks.ini thresholds."""
+    return get_rank_for_value(ehb, EHB_SECTION, ranks_file)
+
+
+def get_ehp_rank(ehp, ranks_file=None):
+    """Return the skilling rank name for an EHP value."""
+    return get_rank_for_value(ehp, EHP_SECTION, ranks_file)
 
 
 def _bootstrap_ranks_from_csv():
@@ -57,17 +95,30 @@ def load_ranks():
             return _bootstrap_ranks_from_csv()
     return _bootstrap_ranks_from_csv()
 
+def _sanitize_player_entry(pdata):
+    """Return a persisted player entry, preserving EHP fields only when present.
+
+    Preserving EHP keys conditionally keeps the JSON backward-compatible: pre-EHP
+    rows round-trip byte-for-byte, while EHP-tracked rows retain their fields.
+    """
+    entry = {
+        "last_ehb": pdata.get("last_ehb", 0),
+        "rank": pdata.get("rank", "Unknown"),
+    }
+    if "last_ehp" in pdata or "ehp_rank" in pdata:
+        entry["last_ehp"] = pdata.get("last_ehp", 0)
+        entry["ehp_rank"] = pdata.get("ehp_rank", "Unknown")
+    return entry
+
+
 def save_ranks(data):
     """Save ranks to ``player_ranks.json`` and sync the latest snapshot to SQLite."""
     sanitized_data = {
-        username: {
-            "last_ehb": pdata.get("last_ehb", 0),
-            "rank": pdata.get("rank", "Unknown"),
-        }
+        username: _sanitize_player_entry(pdata)
         for username, pdata in data.items()
     }
 
-    # Load existing data to compare EHB values
+    # Load existing data to compare EHB / EHP values
     old_data = {}
     if os.path.exists(RANKS_FILE):
         try:
@@ -86,11 +137,64 @@ def save_ranks(data):
             for username, pdata in sanitized_data.items()
             if old_data.get(username, {}).get("last_ehb") != pdata.get("last_ehb")
             or old_data.get(username, {}).get("rank") != pdata.get("rank")
+            or old_data.get(username, {}).get("last_ehp") != pdata.get("last_ehp")
+            or old_data.get(username, {}).get("ehp_rank") != pdata.get("ehp_rank")
         }
         if changed_rows:
             upsert_players(changed_rows)
     except Exception as e:
         print(f"Error updating SQLite player snapshot: {e}")
+
+def _next_rank_for(current_rank, section, unit_label):
+    """Return the next-rank description for a current rank within a ranks section."""
+    rank_thresholds = [(lower, name) for lower, _upper, name in get_rank_thresholds(section)]
+
+    for i, (threshold, rank_name) in enumerate(rank_thresholds):
+        if current_rank == rank_name and i + 1 < len(rank_thresholds):
+            next_rank_name = rank_thresholds[i + 1][1]
+            next_threshold = rank_thresholds[i + 1][0]
+            return f"{next_rank_name} at {next_threshold} {unit_label}"
+
+    return "Max Rank Achieved 👑"  # If they are at the highest rank
+
+
+def compute_member_update(last_data, ehb, rank, ehp=None, ehp_rank=None, track_ehp=False):
+    """Merge new EHB/EHP values into a member's stored entry (pure).
+
+    Returns a dict with the merged ``entry`` plus decision flags the caller uses
+    to drive side effects (Discord notifications, CSV/DB logging). EHB and EHP are
+    evaluated independently so an EHP-only rank-up is never swallowed by a flat EHB.
+    """
+    last_data = last_data or {}
+    entry = dict(last_data)
+
+    last_ehb = last_data.get("last_ehb", 0)
+    last_rank = last_data.get("rank", "Unknown")
+
+    ehb_increase = ehb > last_ehb
+    if ehb_increase:
+        entry["last_ehb"] = ehb
+        entry["rank"] = rank
+    elif rank != last_rank:
+        entry["rank"] = rank
+
+    ehp_increase = False
+    last_ehp_rank = last_data.get("ehp_rank", "Unknown")
+    if track_ehp and ehp is not None:
+        last_ehp = last_data.get("last_ehp", 0)
+        ehp_increase = ehp > last_ehp
+        if ehp_increase or ehp_rank != last_ehp_rank:
+            entry["last_ehp"] = ehp
+            entry["ehp_rank"] = ehp_rank
+
+    return {
+        "entry": entry,
+        "ehb_increase": ehb_increase,
+        "ehb_old_rank": last_rank,
+        "ehp_increase": ehp_increase,
+        "ehp_old_rank": last_ehp_rank,
+    }
+
 
 def next_rank(username):
     """Returns the next rank for a given player based on their current EHB."""
@@ -101,34 +205,26 @@ def next_rank(username):
         if not user_data:
             return "Unknown"  # Return 'Unknown' if the user is not found
 
-        current_ehb = user_data.get("last_ehb", 0)
         current_rank = user_data.get("rank", "Unknown")
-
-        # Load rank thresholds from ranks.ini
-        config = configparser.ConfigParser()
-        config.read(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'ranks.ini'))
-
-        rank_thresholds = []
-        for range_key, rank_name in config['Group Ranking'].items():
-            if '+' in range_key:  # Handle "1500+" case
-                lower_bound = int(range_key.replace('+', ''))
-                rank_thresholds.append((lower_bound, rank_name))
-            else:
-                lower_bound, upper_bound = map(int, range_key.split('-'))
-                rank_thresholds.append((lower_bound, rank_name))
-
-        # Sort by EHB threshold
-        rank_thresholds.sort()
-
-        # Find the next rank
-        for i, (ehb_threshold, rank_name) in enumerate(rank_thresholds):
-            if current_rank == rank_name and i + 1 < len(rank_thresholds):
-                next_rank_name = rank_thresholds[i + 1][1]
-                next_ehb_threshold = rank_thresholds[i + 1][0]
-                return  f"{next_rank_name} at {next_ehb_threshold} EHB"
-        
-        return "Max Rank Achieved 👑"  # If they are at the highest rank
+        return _next_rank_for(current_rank, EHB_SECTION, "EHB")
 
     except Exception as e:
         print(f"Error in next_rank function: {e}")
+        return "Error fetching next rank"
+
+
+def next_rank_ehp(username):
+    """Returns the next skilling rank for a given player based on their current EHP."""
+    try:
+        ranks_data = load_ranks()
+        user_data = ranks_data.get(username)
+
+        if not user_data:
+            return "Unknown"
+
+        current_rank = user_data.get("ehp_rank", "Unknown")
+        return _next_rank_for(current_rank, EHP_SECTION, "EHP")
+
+    except Exception as e:
+        print(f"Error in next_rank_ehp function: {e}")
         return "Error fetching next rank"

--- a/python/utils/rank_utils.py
+++ b/python/utils/rank_utils.py
@@ -96,18 +96,26 @@ def load_ranks():
     return _bootstrap_ranks_from_csv()
 
 def _sanitize_player_entry(pdata):
-    """Return a persisted player entry, preserving EHP fields only when present.
+    """Return a persisted player entry, preserving optional and future fields.
 
     Preserving EHP keys conditionally keeps the JSON backward-compatible: pre-EHP
     rows round-trip byte-for-byte, while EHP-tracked rows retain their fields.
     """
-    entry = {
-        "last_ehb": pdata.get("last_ehb", 0),
-        "rank": pdata.get("rank", "Unknown"),
-    }
+    pdata = pdata or {}
+    entry = dict(pdata)
+    entry.setdefault("last_ehb", 0)
+    entry.setdefault("rank", "Unknown")
     if "last_ehp" in pdata or "ehp_rank" in pdata:
-        entry["last_ehp"] = pdata.get("last_ehp", 0)
-        entry["ehp_rank"] = pdata.get("ehp_rank", "Unknown")
+        entry.setdefault("last_ehp", 0)
+        entry.setdefault("ehp_rank", "Unknown")
+    return entry
+
+
+def merge_manual_rank_update(last_data: dict, ehb: float, rank: str) -> dict:
+    """Return a manual EHB update without discarding unrelated player state."""
+    entry = dict(last_data or {})
+    entry["last_ehb"] = ehb
+    entry["rank"] = rank
     return entry
 
 
@@ -149,13 +157,19 @@ def _next_rank_for(current_rank, section, unit_label):
     """Return the next-rank description for a current rank within a ranks section."""
     rank_thresholds = [(lower, name) for lower, _upper, name in get_rank_thresholds(section)]
 
-    for i, (threshold, rank_name) in enumerate(rank_thresholds):
-        if current_rank == rank_name and i + 1 < len(rank_thresholds):
-            next_rank_name = rank_thresholds[i + 1][1]
-            next_threshold = rank_thresholds[i + 1][0]
-            return f"{next_rank_name} at {next_threshold} {unit_label}"
+    if not rank_thresholds:
+        return "Unknown"
 
-    return "Max Rank Achieved 👑"  # If they are at the highest rank
+    for i, (threshold, rank_name) in enumerate(rank_thresholds):
+        if current_rank != rank_name:
+            continue
+        if i + 1 == len(rank_thresholds):
+            return "Max Rank Achieved 👑"
+        next_rank_name = rank_thresholds[i + 1][1]
+        next_threshold = rank_thresholds[i + 1][0]
+        return f"{next_rank_name} at {next_threshold} {unit_label}"
+
+    return "Unknown"
 
 
 def compute_member_update(last_data, ehb, rank, ehp=None, ehp_rank=None, track_ehp=False):

--- a/python/web/routers/charts.py
+++ b/python/web/routers/charts.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 
+from utils.database import read_player_ehp_history
+
 from ..services.csv_service import read_player_ehb_history
+from ..services.gains_service import list_available_metrics, read_player_gains_history
 from ..services.ranks_service import get_rank_snapshot
 from ..ui import render_template
 
@@ -23,6 +26,7 @@ async def charts_page(request: Request):
         request,
         "chart.html",
         players=snapshot.players,
+        gains_metrics=list_available_metrics(),
         data_error=snapshot.error,
     )
 
@@ -31,6 +35,16 @@ async def charts_page(request: Request):
 async def ehb_history_api(player: str = Query(...)):
     result = read_player_ehb_history(player)
     return JSONResponse(content=result.data, headers=_error_headers(result.error))
+
+
+@router.get("/api/ehp-history")
+async def ehp_history_api(player: str = Query(...)):
+    return JSONResponse(content=read_player_ehp_history(player))
+
+
+@router.get("/api/gains-history")
+async def gains_history_api(player: str = Query(...), metric: str = Query("overall")):
+    return JSONResponse(content=read_player_gains_history(player, metric))
 
 
 @router.get("/api/rank-distribution")

--- a/python/web/routers/reports.py
+++ b/python/web/routers/reports.py
@@ -1,4 +1,4 @@
-"""Reports router - weekly and yearly reports."""
+"""Reports router - weekly, monthly, and yearly reports."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from fastapi.responses import HTMLResponse
 
 from ..dependencies import get_bot_state
 from ..services.bot_state import BotState
-from ..services.report_service import get_weekly_report, get_yearly_report
+from ..services.report_service import get_monthly_report, get_weekly_report, get_yearly_report
 from ..ui import render_template
 
 router = APIRouter()
@@ -54,5 +54,23 @@ async def yearly_report(
         "report_yearly.html",
         report_lines=report_lines,
         year=year,
+        data_error=error,
+    )
+
+
+@router.get("/monthly", response_class=HTMLResponse)
+async def monthly_report(request: Request, state: BotState = Depends(get_bot_state)):
+    try:
+        messages = await get_monthly_report(state)
+        report_lines = [line for message in messages for line in message.split("\n")]
+        error = None
+    except Exception as exc:
+        report_lines = []
+        error = f"Error generating monthly report: {exc}"
+
+    return render_template(
+        request,
+        "report_monthly.html",
+        report_lines=report_lines,
         data_error=error,
     )

--- a/python/web/services/bot_state.py
+++ b/python/web/services/bot_state.py
@@ -39,4 +39,5 @@ class BotState:
     log_buffer: deque = field(default_factory=lambda: deque(maxlen=500))
     last_rank_check: Optional[datetime] = None
     last_group_refresh: Optional[datetime] = None
+    last_gains_snapshot: Optional[datetime] = None
     bot_started_at: Optional[datetime] = None

--- a/python/web/services/gains_service.py
+++ b/python/web/services/gains_service.py
@@ -1,0 +1,42 @@
+"""Service layer for reading persisted gains-snapshot history (Feature 4).
+
+Reads exclusively from SQLite; never touches the live Wise Old Man API.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from utils.database import list_gains_metrics, read_gains_history, read_latest_gains
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_METRICS = ["overall", "ehb"]
+
+
+def list_available_metrics() -> list[str]:
+    """Return metrics that have stored gains, falling back to sensible defaults."""
+    try:
+        metrics = list_gains_metrics()
+    except Exception:
+        logger.exception("Failed to list gains metrics")
+        metrics = []
+    return metrics or list(_DEFAULT_METRICS)
+
+
+def read_player_gains_history(username: str, metric: str) -> list[dict]:
+    """Return ``[{timestamp, gained}]`` gains history for a player + metric."""
+    try:
+        return read_gains_history(username, metric)
+    except Exception:
+        logger.exception("Failed to read gains history for %s/%s", username, metric)
+        return []
+
+
+def read_latest_gains_leaderboard(metric: str, limit: int = 20) -> list[dict]:
+    """Return the most recent stored gains leaderboard for a metric."""
+    try:
+        return read_latest_gains(metric, limit)
+    except Exception:
+        logger.exception("Failed to read latest gains for %s", metric)
+        return []

--- a/python/web/services/ranks_service.py
+++ b/python/web/services/ranks_service.py
@@ -2,18 +2,20 @@
 
 from __future__ import annotations
 
-import configparser
 import logging
-import os
 from dataclasses import dataclass
 
-from utils.rank_utils import load_ranks, next_rank
+from utils.rank_utils import (
+    EHB_SECTION,
+    get_rank_thresholds as _get_rank_thresholds,
+    load_ranks,
+    next_rank,
+    next_rank_ehp,
+)
 
 from ..presentation import RANK_ORDER, canonicalize_rank_name
 
 logger = logging.getLogger(__name__)
-
-_RANKS_INI = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "ranks.ini")
 
 
 @dataclass
@@ -33,6 +35,9 @@ def _build_player(username: str, data: dict) -> dict:
         "username": username,
         "ehb": data.get("last_ehb", 0),
         "rank": canonicalize_rank_name(data.get("rank", "Unknown")),
+        # EHP fields default gracefully for pre-EHP rows.
+        "ehp": data.get("last_ehp", 0),
+        "ehp_rank": data.get("ehp_rank", "Unknown"),
     }
 
 
@@ -92,6 +97,7 @@ def get_player_detail(username: str, snapshot: RankSnapshot | None = None) -> di
             return {
                 **player,
                 "next_rank": next_rank(player["username"]),
+                "next_rank_ehp": next_rank_ehp(player["username"]),
             }
     return None
 
@@ -119,25 +125,13 @@ def search_players(query: str, sort: str = "ehb", snapshot: RankSnapshot | None 
     return players
 
 
-def get_rank_thresholds() -> list[dict]:
-    """Read ranks.ini and return ordered list of threshold dicts."""
-    config = configparser.ConfigParser()
-    config.read(_RANKS_INI)
-    thresholds = []
-    for range_key, rank_name in config["Group Ranking"].items():
-        if "+" in range_key:
-            lower = int(range_key.replace("+", ""))
-            thresholds.append({
-                "lower": lower,
-                "upper": None,
-                "name": canonicalize_rank_name(rank_name),
-            })
-        else:
-            lower, upper = map(int, range_key.split("-"))
-            thresholds.append({
-                "lower": lower,
-                "upper": upper,
-                "name": canonicalize_rank_name(rank_name),
-            })
-    thresholds.sort(key=lambda threshold: threshold["lower"])
-    return thresholds
+def get_rank_thresholds(section: str = EHB_SECTION) -> list[dict]:
+    """Read ranks.ini and return ordered list of threshold dicts for a section."""
+    return [
+        {
+            "lower": lower,
+            "upper": upper,
+            "name": canonicalize_rank_name(name),
+        }
+        for lower, upper, name in _get_rank_thresholds(section)
+    ]

--- a/python/web/services/report_service.py
+++ b/python/web/services/report_service.py
@@ -3,8 +3,10 @@
 from datetime import datetime, timezone
 
 from weeklyupdater import (
+    generate_monthly_report_messages,
     generate_weekly_report_messages,
     generate_yearly_report_messages,
+    most_recent_month_end,
     most_recent_week_end,
     most_recent_year_end,
 )
@@ -26,6 +28,22 @@ async def get_weekly_report(bot_state):
         log=log,
     )
     return messages
+
+
+async def get_monthly_report(bot_state):
+    """Generate the most recent completed calendar-month report."""
+    end_date = most_recent_month_end(datetime.now(timezone.utc))
+
+    def log(msg):
+        if bot_state.log_func:
+            bot_state.log_func(msg)
+
+    return await generate_monthly_report_messages(
+        wom_client=bot_state.wom_client,
+        group_id=bot_state.group_id,
+        end_date=end_date,
+        log=log,
+    )
 
 
 async def get_yearly_report(bot_state, year=None):

--- a/python/web/static/js/app.js
+++ b/python/web/static/js/app.js
@@ -251,6 +251,8 @@ async function renderPlayerMetricHistory(url, label, valueKey, canvasId, message
             labels: result.data.map((entry) => entry.timestamp),
             datasets: [{
                 label,
+                // valueKey is a fixed, developer-supplied metric name (not user input); entry is our own API row.
+                // eslint-disable-next-line security/detect-object-injection
                 data: result.data.map((entry) => entry[valueKey]),
                 borderColor: color,
                 backgroundColor: "rgba(220, 188, 113, 0.16)",

--- a/python/web/static/js/app.js
+++ b/python/web/static/js/app.js
@@ -228,6 +228,124 @@ async function renderPlayerHistory(username, canvasId, messageId) {
     chartInstances.set(canvasId, chart);
 }
 
+async function renderPlayerMetricHistory(url, label, valueKey, canvasId, messageId, color) {
+    const canvas = document.getElementById(canvasId);
+    if (!canvas) {
+        return;
+    }
+    destroyChart(canvasId);
+    chartMessage(messageId, "Loading chart...");
+    const result = await fetchJson(url);
+    if (result.error) {
+        chartMessage(messageId, result.error, true);
+        return;
+    }
+    if (!result.data?.length) {
+        chartMessage(messageId, `No ${label} data is available for this player.`);
+        return;
+    }
+    chartMessage(messageId, `${label} loaded.`);
+    const chart = new Chart(canvas, {
+        type: "line",
+        data: {
+            labels: result.data.map((entry) => entry.timestamp),
+            datasets: [{
+                label,
+                data: result.data.map((entry) => entry[valueKey]),
+                borderColor: color,
+                backgroundColor: "rgba(220, 188, 113, 0.16)",
+                fill: true,
+                tension: 0.28,
+            }],
+        },
+        options: baseChartOptions(label, {
+            plugins: {
+                ...baseChartOptions(label).plugins,
+                legend: { display: false },
+            },
+        }),
+    });
+    chartInstances.set(canvasId, chart);
+}
+
+function initEhpHistoryPlayer() {
+    const container = document.querySelector("[data-player-ehp-player]");
+    if (!container) {
+        return;
+    }
+    const username = container.dataset.playerEhpPlayer;
+    renderPlayerMetricHistory(
+        `/charts/api/ehp-history?player=${encodeURIComponent(username)}`,
+        `${username} - EHP History`,
+        "ehp",
+        container.dataset.ehpTarget,
+        container.dataset.ehpMessage,
+        "#6fb2d6",
+    );
+}
+
+function initEhpHistorySelect() {
+    const container = document.querySelector("[data-player-ehp-select]");
+    if (!container) {
+        return;
+    }
+    const select = container.querySelector("select");
+    const canvasId = container.dataset.ehpTarget;
+    const messageId = container.dataset.ehpMessage;
+    if (!select) {
+        return;
+    }
+    select.addEventListener("change", () => {
+        if (!select.value) {
+            chartMessage(messageId, "Choose a player to load their EHP history.");
+            destroyChart(canvasId);
+            return;
+        }
+        renderPlayerMetricHistory(
+            `/charts/api/ehp-history?player=${encodeURIComponent(select.value)}`,
+            `${select.value} - EHP History`,
+            "ehp",
+            canvasId,
+            messageId,
+            "#6fb2d6",
+        );
+    });
+}
+
+function initGainsSelect() {
+    const container = document.querySelector("[data-player-gains-select]");
+    if (!container) {
+        return;
+    }
+    const select = container.querySelector("select");
+    const metricSelect = container.querySelector("[data-gains-metric]");
+    const canvasId = container.dataset.gainsTarget;
+    const messageId = container.dataset.gainsMessage;
+    if (!select) {
+        return;
+    }
+    const load = () => {
+        if (!select.value) {
+            chartMessage(messageId, "Choose a player to load their gains history.");
+            destroyChart(canvasId);
+            return;
+        }
+        const metric = metricSelect ? metricSelect.value : "overall";
+        renderPlayerMetricHistory(
+            `/charts/api/gains-history?player=${encodeURIComponent(select.value)}&metric=${encodeURIComponent(metric)}`,
+            `${select.value} - ${metric} gains`,
+            "gained",
+            canvasId,
+            messageId,
+            "#c8a24a",
+        );
+    };
+    select.addEventListener("change", load);
+    if (metricSelect) {
+        metricSelect.addEventListener("change", load);
+    }
+}
+
 function initHistorySelect() {
     const container = document.querySelector("[data-player-history-select]");
     if (!container) {
@@ -264,4 +382,7 @@ document.addEventListener("DOMContentLoaded", () => {
     loadTopPlayers();
     initHistorySelect();
     initHistoryPlayer();
+    initEhpHistoryPlayer();
+    initEhpHistorySelect();
+    initGainsSelect();
 });

--- a/python/web/templates/chart.html
+++ b/python/web/templates/chart.html
@@ -60,4 +60,60 @@
         <canvas id="playerChart"></canvas>
     </div>
 </article>
+
+<article class="surface-card"
+         data-player-ehp-select
+         data-ehp-target="playerEhpChart"
+         data-ehp-message="player-ehp-message">
+    <div class="section-heading">
+        <div>
+            <p class="eyebrow">Player drilldown</p>
+            <h2>Individual EHP history</h2>
+        </div>
+    </div>
+    <div class="control-row">
+        <label for="ehpPlayerSelect">Player</label>
+        <select id="ehpPlayerSelect">
+            <option value="">Select a player...</option>
+            {% for player in players %}
+            <option value="{{ player.username }}">{{ player.username }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <p id="player-ehp-message" class="chart-message">Choose a player to load their EHP history.</p>
+    <div class="chart-frame" data-chart-panel>
+        <canvas id="playerEhpChart"></canvas>
+    </div>
+</article>
+
+<article class="surface-card"
+         data-player-gains-select
+         data-gains-target="playerGainsChart"
+         data-gains-message="player-gains-message">
+    <div class="section-heading">
+        <div>
+            <p class="eyebrow">Player drilldown</p>
+            <h2>Gains history</h2>
+        </div>
+    </div>
+    <div class="control-row">
+        <label for="gainsPlayerSelect">Player</label>
+        <select id="gainsPlayerSelect">
+            <option value="">Select a player...</option>
+            {% for player in players %}
+            <option value="{{ player.username }}">{{ player.username }}</option>
+            {% endfor %}
+        </select>
+        <label for="gainsMetricSelect">Metric</label>
+        <select id="gainsMetricSelect" data-gains-metric>
+            {% for metric in gains_metrics %}
+            <option value="{{ metric }}">{{ metric }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <p id="player-gains-message" class="chart-message">Choose a player to load their gains history.</p>
+    <div class="chart-frame" data-chart-panel>
+        <canvas id="playerGainsChart"></canvas>
+    </div>
+</article>
 {% endblock %}

--- a/python/web/templates/partials/player_row.html
+++ b/python/web/templates/partials/player_row.html
@@ -5,10 +5,12 @@
     <td><a href="/players/{{ player.username }}">{{ player.username }}</a></td>
     <td><span class="rank-badge rank-{{ player.rank|rank_slug }}">{{ player.rank }}</span></td>
     <td>{{ "%.2f"|format(player.ehb) }}</td>
+    <td>{{ player.ehp_rank if player.ehp_rank else "Unknown" }}</td>
+    <td>{{ "%.2f"|format(player.ehp or 0) }}</td>
 </tr>
 {% endfor %}
 {% else %}
 <tr>
-    <td colspan="4" class="empty-cell">No players matched{% if query %} "{{ query }}"{% endif %}.</td>
+    <td colspan="6" class="empty-cell">No players matched{% if query %} "{{ query }}"{% endif %}.</td>
 </tr>
 {% endif %}

--- a/python/web/templates/player_detail.html
+++ b/python/web/templates/player_detail.html
@@ -25,6 +25,18 @@
         <p class="mini-label">Next milestone</p>
         <p class="stat-value smaller">{{ player.next_rank if player.next_rank else "Max rank" }}</p>
     </article>
+    <article class="surface-card stat-card">
+        <p class="mini-label">Current EHP</p>
+        <p class="stat-value">{{ "%.2f"|format(player.ehp or 0) }}</p>
+    </article>
+    <article class="surface-card stat-card">
+        <p class="mini-label">Skilling rank</p>
+        <p class="stat-value smaller">{{ player.ehp_rank if player.ehp_rank else "Unknown" }}</p>
+    </article>
+    <article class="surface-card stat-card">
+        <p class="mini-label">Next skilling rank</p>
+        <p class="stat-value smaller">{{ player.next_rank_ehp if player.next_rank_ehp else "Max rank" }}</p>
+    </article>
 </section>
 
 <section class="content-grid">
@@ -45,6 +57,21 @@
         {% endif %}
         <div class="chart-frame" data-chart-panel>
             <canvas id="ehbChart"></canvas>
+        </div>
+    </article>
+    <article class="surface-card"
+             data-player-ehp-player="{{ player.username }}"
+             data-ehp-target="ehpChart"
+             data-ehp-message="ehp-chart-message">
+        <div class="section-heading">
+            <div>
+                <p class="eyebrow">Progression</p>
+                <h2>EHP history</h2>
+            </div>
+        </div>
+        <p id="ehp-chart-message" class="chart-message">Loading chart...</p>
+        <div class="chart-frame" data-chart-panel>
+            <canvas id="ehpChart"></canvas>
         </div>
     </article>
 </section>

--- a/python/web/templates/player_list.html
+++ b/python/web/templates/player_list.html
@@ -42,6 +42,8 @@
                     <th>Player</th>
                     <th>Rank</th>
                     <th>EHB</th>
+                    <th>Skill Rank</th>
+                    <th>EHP</th>
                 </tr>
             </thead>
             <tbody id="player-results">

--- a/python/web/templates/report_monthly.html
+++ b/python/web/templates/report_monthly.html
@@ -1,20 +1,19 @@
 {% extends "base.html" %}
 
-{% block title %}Weekly Report - WOMupdtr{% endblock %}
+{% block title %}Monthly Report - WOMupdtr{% endblock %}
 
 {% block content %}
 <section class="hero-panel compact">
     <div>
         <p class="eyebrow">Reports</p>
-        <h1>Weekly Report</h1>
-        <p class="lede">Generate and inspect the most recent weekly rollup from the web dashboard.</p>
+        <h1>Monthly Report</h1>
+        <p class="lede">Inspect the most recent completed calendar-month rollup.</p>
     </div>
-    <a href="/reports/weekly?fresh=true" role="button" class="secondary">Generate fresh report</a>
 </section>
 
 <nav class="player-controls" aria-label="Report type">
-    <a href="/reports/weekly" role="button">Weekly</a>
-    <a href="/reports/monthly" role="button" class="secondary">Monthly</a>
+    <a href="/reports/weekly" role="button" class="secondary">Weekly</a>
+    <a href="/reports/monthly" role="button">Monthly</a>
     <a href="/reports/yearly" role="button" class="secondary">Yearly</a>
 </nav>
 
@@ -23,7 +22,7 @@
     <pre class="report-output">{% for line in report_lines %}{{ line }}
 {% endfor %}</pre>
     {% else %}
-    <p class="empty-state">No weekly report data is available yet.</p>
+    <p class="empty-state">No monthly report data is available yet.</p>
     {% endif %}
 </article>
 {% endblock %}

--- a/python/web/templates/report_yearly.html
+++ b/python/web/templates/report_yearly.html
@@ -11,6 +11,12 @@
     </div>
 </section>
 
+<nav class="player-controls" aria-label="Report type">
+    <a href="/reports/weekly" role="button" class="secondary">Weekly</a>
+    <a href="/reports/monthly" role="button" class="secondary">Monthly</a>
+    <a href="/reports/yearly" role="button">Yearly</a>
+</nav>
+
 <article class="surface-card">
     <form method="get" action="/reports/yearly" class="player-controls">
         <label>

--- a/python/weeklyupdater/__init__.py
+++ b/python/weeklyupdater/__init__.py
@@ -6,6 +6,12 @@ from .weekly_reporter import (
     send_weekly_report,
     start_weekly_reporter,
 )
+from .monthly_reporter import (
+    generate_monthly_report_messages,
+    most_recent_month_end,
+    send_monthly_report,
+    start_monthly_reporter,
+)
 from .yearly_reporter import (
     generate_yearly_report_messages,
     most_recent_year_end,
@@ -19,6 +25,10 @@ __all__ = [
     "most_recent_week_end",
     "send_weekly_report",
     "start_weekly_reporter",
+    "generate_monthly_report_messages",
+    "most_recent_month_end",
+    "send_monthly_report",
+    "start_monthly_reporter",
     "generate_yearly_report_messages",
     "most_recent_year_end",
     "send_yearly_report",

--- a/python/weeklyupdater/monthly_reporter.py
+++ b/python/weeklyupdater/monthly_reporter.py
@@ -1,0 +1,272 @@
+"""Monthly group report scheduler and data collector."""
+
+from __future__ import annotations
+
+import asyncio
+import calendar
+from datetime import datetime, timezone
+
+from wom import enums
+
+from .weekly_reporter import (
+    _chunk_messages,
+    _format_float,
+    _format_int,
+    _get_group_gains,
+    _is_experience_measure,
+    _is_level_measure,
+    _is_skill_metric,
+    _matches_threshold,
+    _metric_label,
+    _LEVEL_99_XP,
+)
+
+
+def _month_boundary_1200_utc(year: int, month: int) -> datetime:
+    return datetime(year, month, 1, 12, 0, tzinfo=timezone.utc)
+
+
+def _previous_month_boundary(boundary: datetime) -> datetime:
+    if boundary.month == 1:
+        return _month_boundary_1200_utc(boundary.year - 1, 12)
+    return _month_boundary_1200_utc(boundary.year, boundary.month - 1)
+
+
+def _most_recent_month_end(now: datetime) -> datetime:
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    boundary = _month_boundary_1200_utc(now.year, now.month)
+    if now < boundary:
+        boundary = _previous_month_boundary(boundary)
+    return boundary
+
+
+def _next_month_end(now: datetime) -> datetime:
+    boundary = _most_recent_month_end(now)
+    if boundary.month == 12:
+        return _month_boundary_1200_utc(boundary.year + 1, 1)
+    return _month_boundary_1200_utc(boundary.year, boundary.month + 1)
+
+
+async def _get_group_member_map(wom_client, group_id: int, log) -> dict[int, str]:
+    result = await wom_client.groups.get_details(group_id)
+    if not result.is_ok:
+        log(f"Monthly report: failed to fetch group details: {result.unwrap_err()}")
+        return {}
+    group = result.unwrap()
+    return {membership.player.id: membership.player.display_name for membership in group.memberships}
+
+
+async def _get_dated_pages(
+    fetch_page,
+    *,
+    start_date: datetime,
+    end_date: datetime,
+    log,
+    label: str,
+    limit: int = 50,
+) -> list:
+    entries = []
+    offset = 0
+    while True:
+        result = await fetch_page(limit, offset)
+        if not result.is_ok:
+            log(f"Monthly report: failed to fetch {label}: {result.unwrap_err()}")
+            break
+        page = list(result.unwrap())
+        if not page:
+            break
+        entries.extend(item for item in page if start_date <= item.created_at < end_date)
+        if len(page) < limit or page[-1].created_at < start_date:
+            break
+        offset += limit
+    return entries
+
+
+def _build_report_lines(
+    *,
+    start_date: datetime,
+    end_date: datetime,
+    overall_gains: list,
+    ehb_gains: list,
+    ehp_gains: list,
+    sailing_gains: list,
+    name_changes: list,
+    achievements: list,
+    player_name_map: dict[int, str],
+) -> list[str]:
+    month_label = f"{calendar.month_name[start_date.month]} {start_date.year}"
+    lines = [
+        f"Monthly Report - {month_label}",
+        f"({start_date.strftime('%Y-%m-%d %H:%M')} UTC - {end_date.strftime('%Y-%m-%d %H:%M')} UTC)",
+        "",
+    ]
+
+    total_xp = sum(entry.data.gained for entry in overall_gains)
+    active_members = sum(1 for entry in overall_gains if entry.data.gained > 0)
+    lines.extend(
+        [
+            "Month at a glance",
+            f"- Group XP gained: {_format_int(total_xp)} xp",
+            f"- Active gainers: {active_members}/{len(player_name_map)} members",
+            f"- Group EHB gained: {_format_float(sum(entry.data.gained for entry in ehb_gains))}",
+            f"- Group EHP gained: {_format_float(sum(entry.data.gained for entry in ehp_gains))}",
+            f"- New 99s: {len(achievements)}",
+            "",
+        ]
+    )
+
+    metric_sections = (
+        ("Top overall XP gainers", overall_gains, "xp", _format_int, 5),
+        ("Top EHB gainers", ehb_gains, "EHB", _format_float, 5),
+        ("Top EHP gainers", ehp_gains, "EHP", _format_float, 5),
+        ("Top Sailing gainers", sailing_gains, "xp", _format_int, 3),
+    )
+    for title, gains, unit, formatter, count in metric_sections:
+        if gains:
+            lines.append(f"{title}:")
+            for index, entry in enumerate(gains[:count], start=1):
+                lines.append(
+                    f"{index}. {entry.player.display_name} (+{formatter(entry.data.gained)} {unit})"
+                )
+        else:
+            lines.append(f"{title}: no data")
+        lines.append("")
+
+    if achievements:
+        lines.append("New 99s:")
+        grouped: dict[str, list[str]] = {}
+        for achievement in achievements:
+            name = player_name_map.get(achievement.player_id, f"Player {achievement.player_id}")
+            grouped.setdefault(name, []).append(_metric_label(achievement.metric))
+        for name in sorted(grouped, key=str.casefold):
+            lines.append(f"- {name}: {', '.join(grouped[name])}")
+    else:
+        lines.append("New 99s: none")
+    lines.append("")
+
+    if name_changes:
+        lines.append(f"Name changes: {len(name_changes)}")
+        for change in name_changes[:10]:
+            lines.append(
+                f"- {change.old_name} -> {change.new_name} "
+                f"({change.status.value}, {change.created_at.strftime('%Y-%m-%d')})"
+            )
+        if len(name_changes) > 10:
+            lines.append(f"...and {len(name_changes) - 10} more name changes")
+    else:
+        lines.append("Name changes: none")
+
+    return lines
+
+
+async def _generate_monthly_report(*, wom_client, group_id: int, end_date: datetime, log) -> list[str]:
+    start_date = _previous_month_boundary(end_date)
+    player_name_map = await _get_group_member_map(wom_client, group_id, log)
+
+    overall_gains = await _get_group_gains(
+        wom_client, group_id, enums.Metric.Overall, start_date, end_date, limit=50
+    )
+    ehb_gains = await _get_group_gains(
+        wom_client, group_id, enums.Metric.Ehb, start_date, end_date, limit=50
+    )
+    ehp_gains = await _get_group_gains(
+        wom_client, group_id, enums.Metric.Ehp, start_date, end_date, limit=50
+    )
+    sailing_gains = await _get_group_gains(
+        wom_client, group_id, enums.Metric.Sailing, start_date, end_date, limit=50
+    )
+
+    groups = wom_client.groups
+    name_changes = await _get_dated_pages(
+        lambda limit, offset: groups.get_name_changes(group_id, limit=limit, offset=offset),
+        start_date=start_date,
+        end_date=end_date,
+        log=log,
+        label="name changes",
+    )
+    raw_achievements = await _get_dated_pages(
+        lambda limit, offset: groups.get_achievements(group_id, limit=limit, offset=offset),
+        start_date=start_date,
+        end_date=end_date,
+        log=log,
+        label="achievements",
+    )
+    achievements = [
+        item
+        for item in raw_achievements
+        if _is_skill_metric(item.metric)
+        and (
+            (_is_level_measure(item.measure) and _matches_threshold(item.threshold, 99))
+            or (_is_experience_measure(item.measure) and _matches_threshold(item.threshold, _LEVEL_99_XP))
+        )
+    ]
+
+    for gains in (overall_gains, ehb_gains, ehp_gains, sailing_gains):
+        gains.sort(key=lambda entry: entry.data.gained, reverse=True)
+    achievements.sort(key=lambda item: item.created_at)
+    name_changes.sort(key=lambda item: item.created_at)
+
+    return _chunk_messages(
+        _build_report_lines(
+            start_date=start_date,
+            end_date=end_date,
+            overall_gains=overall_gains,
+            ehb_gains=ehb_gains,
+            ehp_gains=ehp_gains,
+            sailing_gains=sailing_gains,
+            name_changes=name_changes,
+            achievements=achievements,
+            player_name_map=player_name_map,
+        )
+    )
+
+
+async def _send_report(discord_client, channel_id: int, messages: list[str], log) -> None:
+    channel = discord_client.get_channel(channel_id)
+    if channel is None:
+        log(f"Monthly report: channel {channel_id} not found.")
+        return
+    for message in messages:
+        await channel.send(message)
+
+
+async def _monthly_report_loop(*, wom_client, discord_client, group_id: int, channel_id: int, log, debug: bool) -> None:
+    while True:
+        now = datetime.now(timezone.utc)
+        next_run = _next_month_end(now)
+        if debug:
+            log(f"Monthly report scheduled for {next_run.isoformat()}")
+        await asyncio.sleep(max((next_run - now).total_seconds(), 1))
+        messages = await _generate_monthly_report(
+            wom_client=wom_client, group_id=group_id, end_date=next_run, log=log
+        )
+        await _send_report(discord_client, channel_id, messages, log)
+
+
+def start_monthly_reporter(*, wom_client, discord_client, group_id: int, channel_id: int, log, debug: bool = False) -> asyncio.Task:
+    return asyncio.create_task(
+        _monthly_report_loop(
+            wom_client=wom_client,
+            discord_client=discord_client,
+            group_id=group_id,
+            channel_id=channel_id,
+            log=log,
+            debug=debug,
+        )
+    )
+
+
+def most_recent_month_end(now: datetime) -> datetime:
+    """Return the most recent first-of-month 12:00 UTC boundary."""
+    return _most_recent_month_end(now)
+
+
+async def generate_monthly_report_messages(*, wom_client, group_id: int, end_date: datetime, log) -> list[str]:
+    return await _generate_monthly_report(
+        wom_client=wom_client, group_id=group_id, end_date=end_date, log=log
+    )
+
+
+async def send_monthly_report(*, discord_client, channel_id: int, messages: list[str], log) -> None:
+    await _send_report(discord_client, channel_id, messages, log)

--- a/python/weeklyupdater/weekly_reporter.py
+++ b/python/weeklyupdater/weekly_reporter.py
@@ -117,19 +117,27 @@ async def _get_group_gains(
     *,
     limit: int = 50,
 ) -> list:
-    result = await wom_client.groups.get_gains(
-        group_id,
-        metric,
-        start_date=start_date,
-        end_date=end_date,
-        limit=limit,
-        offset=0,
-    )
+    gains = []
+    offset = 0
+    while True:
+        result = await wom_client.groups.get_gains(
+            group_id,
+            metric,
+            start_date=start_date,
+            end_date=end_date,
+            limit=limit,
+            offset=offset,
+        )
+        if not result.is_ok:
+            return []
 
-    if not result.is_ok:
-        return []
+        page = list(result.unwrap())
+        gains.extend(page)
+        if len(page) < limit:
+            break
+        offset += limit
 
-    return list(result.unwrap())
+    return gains
 
 
 async def _get_group_achievements(
@@ -232,6 +240,11 @@ def _build_report_lines(
     name_changes: list,
     achievements: list,
     player_name_map: dict[int, str],
+    total_xp: t.Optional[float] = None,
+    active_members: t.Optional[int] = None,
+    total_ehb: t.Optional[float] = None,
+    ehp_top: t.Optional[list[tuple[str, float]]] = None,
+    total_ehp: t.Optional[float] = None,
 ) -> list[str]:
     header = (
         "Weekly Report"
@@ -240,6 +253,17 @@ def _build_report_lines(
     )
 
     lines = [header, ""]
+
+    if total_xp is not None:
+        lines.append("Week at a glance")
+        lines.append(f"- Group XP gained: {_format_int(total_xp)} xp")
+        if active_members is not None:
+            lines.append(f"- Active gainers: {active_members}/{len(player_name_map)} members")
+        if total_ehb is not None:
+            lines.append(f"- Group EHB gained: {_format_float(total_ehb)}")
+        if total_ehp is not None:
+            lines.append(f"- Group EHP gained: {_format_float(total_ehp)}")
+        lines.append("")
 
     if overall_top:
         lines.append(
@@ -256,6 +280,15 @@ def _build_report_lines(
             lines.append(f"{idx}. {name} (+{_format_float(gained)} EHB)")
     else:
         lines.append("Top EHB gainers: no data")
+
+    lines.append("")
+
+    if ehp_top:
+        lines.append("Top EHP gainers:")
+        for idx, (name, gained) in enumerate(ehp_top, start=1):
+            lines.append(f"{idx}. {name} (+{_format_float(gained)} EHP)")
+    else:
+        lines.append("Top EHP gainers: no data")
 
     lines.append("")
 
@@ -309,6 +342,9 @@ async def _generate_weekly_report(
     ehb_gains = await _get_group_gains(
         wom_client, group_id, enums.Metric.Ehb, start_date, end_date, limit=50
     )
+    ehp_gains = await _get_group_gains(
+        wom_client, group_id, enums.Metric.Ehp, start_date, end_date, limit=50
+    )
     sailing_gains = await _get_group_gains(
         wom_client, group_id, enums.Metric.Sailing, start_date, end_date, limit=50 # type: ignore
     )
@@ -322,6 +358,7 @@ async def _generate_weekly_report(
 
     overall_gains.sort(key=lambda entry: entry.data.gained, reverse=True)
     ehb_gains.sort(key=lambda entry: entry.data.gained, reverse=True)
+    ehp_gains.sort(key=lambda entry: entry.data.gained, reverse=True)
     sailing_gains.sort(key=lambda entry: entry.data.gained, reverse=True)
 
     overall_top = None
@@ -333,6 +370,9 @@ async def _generate_weekly_report(
 
     ehb_top = [
         (entry.player.display_name, entry.data.gained) for entry in ehb_gains[:3]
+    ]
+    ehp_top = [
+        (entry.player.display_name, entry.data.gained) for entry in ehp_gains[:3]
     ]
 
     sailing_top = None
@@ -367,6 +407,11 @@ async def _generate_weekly_report(
         name_changes=name_changes,
         achievements=achievements,
         player_name_map=player_name_map,
+        total_xp=sum(entry.data.gained for entry in overall_gains),
+        active_members=sum(1 for entry in overall_gains if entry.data.gained > 0),
+        total_ehb=sum(entry.data.gained for entry in ehb_gains),
+        ehp_top=ehp_top,
+        total_ehp=sum(entry.data.gained for entry in ehp_gains),
     )
 
     return _chunk_messages(lines)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,9 +97,10 @@ def make_gains_entry(player, *, gained=0.0, start_date=None, end_date=None):
 class FakeGroupService:
     """Async group service returning canned FakeResult values."""
 
-    def __init__(self, *, details=None, gains=None, hiscores=None):
+    def __init__(self, *, details=None, gains=None, gains_errors=None, hiscores=None):
         self._details = details
         self._gains = gains or {}
+        self._gains_errors = gains_errors or {}
         self._hiscores = hiscores or {}
         self.calls = []
 
@@ -113,6 +114,9 @@ class FakeGroupService:
                         end_date=None, limit=None, offset=None):
         self.calls.append(("get_gains", metric, limit, offset))
         key = getattr(metric, "value", metric)
+        error = self._gains_errors.get((key, offset or 0))
+        if error is not None:
+            return FakeResult(err=error)
         entries = list(self._gains.get(key, []))
         page = entries[(offset or 0): (offset or 0) + (limit or len(entries))]
         return FakeResult(value=page)
@@ -128,8 +132,13 @@ class FakeGroupService:
 class FakeWomClient:
     """Async WOM client stub exposing a ``groups`` service."""
 
-    def __init__(self, *, details=None, gains=None, hiscores=None):
-        self.groups = FakeGroupService(details=details, gains=gains, hiscores=hiscores)
+    def __init__(self, *, details=None, gains=None, gains_errors=None, hiscores=None):
+        self.groups = FakeGroupService(
+            details=details,
+            gains=gains,
+            gains_errors=gains_errors,
+            hiscores=hiscores,
+        )
 
     async def start(self):
         return None
@@ -138,8 +147,13 @@ class FakeWomClient:
 @pytest.fixture
 def fake_wom_client():
     """Factory fixture for a configurable async WOM client stub."""
-    def _make(*, details=None, gains=None, hiscores=None):
-        return FakeWomClient(details=details, gains=gains, hiscores=hiscores)
+    def _make(*, details=None, gains=None, gains_errors=None, hiscores=None):
+        return FakeWomClient(
+            details=details,
+            gains=gains,
+            gains_errors=gains_errors,
+            hiscores=hiscores,
+        )
     return _make
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import csv
 import json
 import os
 import sys
+import types
 
 import pytest
 
@@ -28,12 +29,118 @@ def isolate_database_path(monkeypatch, tmp_path):
 
 @pytest.fixture
 def sample_players():
-    """Three players at different EHB / rank levels."""
+    """Three players at different EHB / rank levels (with EHP fields)."""
     return {
-        "goblin_gaz": {"last_ehb": 5.0, "rank": "Goblin"},
-        "silver_sam": {"last_ehb": 150.0, "rank": "Silver"},
-        "zenyte_zoe": {"last_ehb": 1600.0, "rank": "Zenyte"},
+        "goblin_gaz": {"last_ehb": 5.0, "rank": "Goblin", "last_ehp": 20.0, "ehp_rank": "Novice"},
+        "silver_sam": {"last_ehb": 150.0, "rank": "Silver", "last_ehp": 400.0, "ehp_rank": "Adept"},
+        "zenyte_zoe": {"last_ehb": 1600.0, "rank": "Zenyte", "last_ehp": 1800.0, "ehp_rank": "Master"},
     }
+
+
+# ---------------------------------------------------------------------------
+# Shared async WOM client stub (Feature foundation F2)
+# ---------------------------------------------------------------------------
+
+
+class FakeResult:
+    """Minimal stand-in for wom.py's ``Result`` type."""
+
+    def __init__(self, value=None, err=None):
+        self._v = value
+        self._e = err
+        self.is_ok = err is None
+
+    def unwrap(self):
+        return self._v
+
+    def unwrap_err(self):
+        return self._e
+
+
+def make_player(display_name, *, ehb=0.0, ehp=0.0, player_id=None, status="active",
+                last_changed_at=None, updated_at=None):
+    """Build a SimpleNamespace matching the fields WOM's Player exposes."""
+    return types.SimpleNamespace(
+        display_name=display_name,
+        id=player_id if player_id is not None else abs(hash(display_name)) % 100000,
+        ehb=ehb,
+        ehp=ehp,
+        status=status,
+        last_changed_at=last_changed_at,
+        updated_at=updated_at,
+    )
+
+
+def make_membership(player):
+    """Build a group-membership namespace wrapping a player."""
+    return types.SimpleNamespace(player=player)
+
+
+def make_hiscores_entry(player, *, kills=0, rank=-1):
+    """Build a GroupHiscoresEntry-shaped namespace (boss data)."""
+    return types.SimpleNamespace(
+        player=player,
+        data=types.SimpleNamespace(kills=kills, rank=rank),
+    )
+
+
+def make_gains_entry(player, *, gained=0.0, start_date=None, end_date=None):
+    """Build a GroupMemberGains-shaped namespace."""
+    return types.SimpleNamespace(
+        player=player,
+        data=types.SimpleNamespace(gained=gained),
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+
+class FakeGroupService:
+    """Async group service returning canned FakeResult values."""
+
+    def __init__(self, *, details=None, gains=None, hiscores=None):
+        self._details = details
+        self._gains = gains or {}
+        self._hiscores = hiscores or {}
+        self.calls = []
+
+    async def get_details(self, group_id):
+        self.calls.append(("get_details", group_id))
+        if self._details is None:
+            return FakeResult(err="no details configured")
+        return FakeResult(value=self._details)
+
+    async def get_gains(self, group_id, metric, *, period=None, start_date=None,
+                        end_date=None, limit=None, offset=None):
+        self.calls.append(("get_gains", metric, limit, offset))
+        key = getattr(metric, "value", metric)
+        entries = list(self._gains.get(key, []))
+        page = entries[(offset or 0): (offset or 0) + (limit or len(entries))]
+        return FakeResult(value=page)
+
+    async def get_hiscores(self, group_id, metric, *, limit=None, offset=None):
+        self.calls.append(("get_hiscores", metric, limit, offset))
+        key = getattr(metric, "value", metric)
+        entries = list(self._hiscores.get(key, []))
+        page = entries[(offset or 0): (offset or 0) + (limit or len(entries))]
+        return FakeResult(value=page)
+
+
+class FakeWomClient:
+    """Async WOM client stub exposing a ``groups`` service."""
+
+    def __init__(self, *, details=None, gains=None, hiscores=None):
+        self.groups = FakeGroupService(details=details, gains=gains, hiscores=hiscores)
+
+    async def start(self):
+        return None
+
+
+@pytest.fixture
+def fake_wom_client():
+    """Factory fixture for a configurable async WOM client stub."""
+    def _make(*, details=None, gains=None, hiscores=None):
+        return FakeWomClient(details=details, gains=gains, hiscores=hiscores)
+    return _make
 
 
 @pytest.fixture
@@ -52,6 +159,13 @@ def ranks_ini_file(tmp_path):
         "750-1000 = Dragonstone\n"
         "1000-1500 = Onyx\n"
         "1500+ = Zenyte\n"
+        "\n"
+        "[Skilling Ranking]\n"
+        "0-100 = Novice\n"
+        "100-500 = Apprentice\n"
+        "500-1000 = Adept\n"
+        "1000-1500 = Expert\n"
+        "1500+ = Master\n"
     )
     return ranks_ini
 
@@ -65,6 +179,11 @@ def tmp_ranks_ini(tmp_path, monkeypatch):
         "0-99 = Bronze\n"
         "100-199 = Silver\n"
         "200+ = Gold\n"
+        "\n"
+        "[Skilling Ranking]\n"
+        "0-99 = Wood\n"
+        "100-199 = Stone\n"
+        "200+ = Steel\n"
     )
     original_read = configparser.ConfigParser.read
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -64,3 +64,69 @@ def test_import_csv_history_skips_duplicates(tmp_path, monkeypatch):
     with sqlite3.connect(db_path) as conn:
         count = conn.execute("SELECT COUNT(*) FROM ehb_history").fetchone()[0]
     assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# Foundation F1 — column migration on an already-deployed table
+# ---------------------------------------------------------------------------
+
+def test_init_database_migrates_pre_existing_players_table(tmp_path):
+    """A legacy players table (no EHP/status columns) gets columns added."""
+    db_path = tmp_path / "database.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE players (
+                username TEXT PRIMARY KEY,
+                last_ehb REAL NOT NULL DEFAULT 0,
+                rank TEXT NOT NULL DEFAULT 'Unknown',
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO players (username, last_ehb, rank, updated_at) VALUES ('alice', 5, 'Goblin', 'x')"
+        )
+        conn.commit()
+
+    database.init_database(str(db_path))
+
+    with sqlite3.connect(db_path) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(players)")}
+    for expected in {"last_ehp", "ehp_rank", "player_id", "wom_status", "last_changed_at"}:
+        assert expected in columns
+
+
+def test_init_database_is_idempotent(tmp_path):
+    db_path = tmp_path / "database.db"
+    database.init_database(str(db_path))
+    # A second call must not raise (duplicate ALTER guarded by _ensure_columns).
+    database.init_database(str(db_path))
+    with sqlite3.connect(db_path) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(players)")}
+    assert "last_ehp" in columns
+
+
+def test_ehp_history_roundtrip(tmp_path):
+    db_path = tmp_path / "database.db"
+    database.log_ehp_history("alice", 120.0, timestamp="2025-01-01 12:00:00", db_path=str(db_path))
+    database.log_ehp_history("alice", 130.0, timestamp="2025-02-01 12:00:00", db_path=str(db_path))
+
+    history = database.read_player_ehp_history("alice", db_path=str(db_path))
+    assert history == [
+        {"timestamp": "2025-01-01 12:00:00", "ehp": 120.0},
+        {"timestamp": "2025-02-01 12:00:00", "ehp": 130.0},
+    ]
+
+
+def test_upsert_players_persists_ehp_fields(tmp_path):
+    db_path = tmp_path / "database.db"
+    database.upsert_players(
+        {"alice": {"last_ehb": 42.5, "rank": "Silver", "last_ehp": 300.0, "ehp_rank": "Adept"}},
+        db_path=str(db_path),
+    )
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT last_ehp, ehp_rank FROM players WHERE username = 'alice'"
+        ).fetchone()
+    assert row == (300.0, "Adept")

--- a/tests/test_gains_snapshotter.py
+++ b/tests/test_gains_snapshotter.py
@@ -2,6 +2,9 @@
 
 import asyncio
 from datetime import datetime, timezone
+import types
+
+import pytest
 
 from python.gainstracker import gains_snapshotter
 from python.utils import database
@@ -141,3 +144,123 @@ def test_collect_gains_leaderboard_sorted(fake_wom_client):
     ))
     assert board[0] == ("high", 999.0)
     assert board[1] == ("low", 10.0)
+
+
+# ---------------------------------------------------------------------------
+# API failure handling and snapshot atomicity
+# ---------------------------------------------------------------------------
+
+def test_snapshot_gains_first_page_failure_writes_nothing(fake_wom_client):
+    client = fake_wom_client(gains_errors={("overall", 0): "WOM unavailable"})
+
+    with pytest.raises(RuntimeError, match="overall.*offset 0.*WOM unavailable"):
+        run(gains_snapshotter.snapshot_gains_once(
+            wom_client=client,
+            group_id=1,
+            metrics=["overall"],
+            window_days=7,
+            log=_log,
+            now=NOW,
+        ))
+
+    assert database.read_latest_gains("overall") == []
+
+
+def test_snapshot_gains_later_page_failure_discards_partial_rows(fake_wom_client):
+    entries = [make_gains_entry(make_player(f"p{i}"), gained=float(i)) for i in range(75)]
+    client = fake_wom_client(
+        gains={"overall": entries},
+        gains_errors={("overall", 50): "page failed"},
+    )
+
+    with pytest.raises(RuntimeError, match="overall.*offset 50.*page failed"):
+        run(gains_snapshotter.snapshot_gains_once(
+            wom_client=client,
+            group_id=1,
+            metrics=["overall"],
+            window_days=7,
+            log=_log,
+            now=NOW,
+        ))
+
+    assert database.read_latest_gains("overall") == []
+
+
+def test_snapshot_gains_multi_metric_failure_is_atomic(fake_wom_client):
+    client = fake_wom_client(
+        gains={"overall": [make_gains_entry(make_player("alice"), gained=5000.0)]},
+        gains_errors={("ehb", 0): "EHB failed"},
+    )
+
+    with pytest.raises(RuntimeError, match="ehb.*offset 0.*EHB failed"):
+        run(gains_snapshotter.snapshot_gains_once(
+            wom_client=client,
+            group_id=1,
+            metrics=["overall", "ehb"],
+            window_days=7,
+            log=_log,
+            now=NOW,
+        ))
+
+    assert database.read_latest_gains("overall") == []
+    assert database.read_latest_gains("ehb") == []
+
+
+def test_snapshot_gains_requires_at_least_one_valid_metric(fake_wom_client):
+    client = fake_wom_client()
+
+    with pytest.raises(ValueError, match="no valid metrics"):
+        run(gains_snapshotter.snapshot_gains_once(
+            wom_client=client,
+            group_id=1,
+            metrics=["not_a_metric"],
+            window_days=7,
+            log=_log,
+            now=NOW,
+        ))
+
+
+def test_live_gains_leaderboard_propagates_api_failure(fake_wom_client):
+    client = fake_wom_client(gains_errors={("overall", 0): "live failed"})
+
+    with pytest.raises(RuntimeError, match="overall.*offset 0.*live failed"):
+        run(gains_snapshotter.collect_gains_leaderboard(
+            wom_client=client,
+            group_id=1,
+            metric_name="overall",
+            window_days=7,
+            log=_log,
+            now=NOW,
+        ))
+
+
+def test_snapshot_loop_does_not_publish_or_mark_failed_cycle(fake_wom_client, monkeypatch):
+    client = fake_wom_client(gains_errors={("overall", 0): "scheduled failure"})
+    snapshot_calls = []
+    channel_lookups = []
+    logs = []
+
+    async def stop_after_first_cycle(_seconds):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(gains_snapshotter.asyncio, "sleep", stop_after_first_cycle)
+    discord_client = types.SimpleNamespace(
+        get_channel=lambda channel_id: channel_lookups.append(channel_id)
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        run(gains_snapshotter._gains_snapshot_loop(
+            wom_client=client,
+            discord_client=discord_client,
+            group_id=1,
+            channel_id=123,
+            metrics=["overall"],
+            window_days=7,
+            interval_seconds=60,
+            log=logs.append,
+            on_snapshot=lambda: snapshot_calls.append(True),
+        ))
+
+    assert snapshot_calls == []
+    assert channel_lookups == []
+    assert any("scheduled failure" in message for message in logs)

--- a/tests/test_gains_snapshotter.py
+++ b/tests/test_gains_snapshotter.py
@@ -1,0 +1,143 @@
+"""Tests for the persisted gains snapshotter — Feature 4."""
+
+import asyncio
+from datetime import datetime, timezone
+
+from python.gainstracker import gains_snapshotter
+from python.utils import database
+from tests.conftest import make_gains_entry, make_player
+
+
+NOW = datetime(2025, 1, 8, 0, 0, tzinfo=timezone.utc)
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+def test_resolve_metric_known():
+    assert gains_snapshotter.resolve_metric("overall") is not None
+    assert gains_snapshotter.resolve_metric("ehb") is not None
+    assert gains_snapshotter.resolve_metric("EHB") is not None
+
+
+def test_resolve_metric_unknown():
+    assert gains_snapshotter.resolve_metric("not_a_metric") is None
+    assert gains_snapshotter.resolve_metric("") is None
+
+
+def test_build_gains_rows_skips_nameless_entries():
+    entries = [
+        make_gains_entry(make_player("alice"), gained=1000.0),
+        make_gains_entry(make_player(""), gained=5.0),  # dropped
+    ]
+    rows = gains_snapshotter._build_gains_rows(
+        entries,
+        snapshot_time="2025-01-08 00:00:00",
+        period_start="2025-01-01 00:00:00",
+        period_end="2025-01-08 00:00:00",
+        metric="overall",
+    )
+    assert len(rows) == 1
+    assert rows[0]["username"] == "alice"
+    assert rows[0]["gained"] == 1000.0
+    assert rows[0]["metric"] == "overall"
+
+
+def test_build_gains_lines_formats_leaderboard():
+    lines = gains_snapshotter.build_gains_lines("overall", 7, [("alice", 5000.0), ("bob", 3000.0)])
+    joined = "\n".join(lines)
+    assert "alice" in joined
+    assert "last 7d" in joined
+
+
+def test_build_gains_lines_empty():
+    lines = gains_snapshotter.build_gains_lines("ehb", 7, [])
+    assert any("No gains data" in line for line in lines)
+
+
+# ---------------------------------------------------------------------------
+# snapshot_gains_once — DB integration
+# ---------------------------------------------------------------------------
+
+def _log(_msg):
+    pass
+
+
+def test_snapshot_gains_once_persists(fake_wom_client, tmp_path):
+    client = fake_wom_client(gains={
+        "overall": [
+            make_gains_entry(make_player("alice"), gained=5000.0),
+            make_gains_entry(make_player("bob"), gained=3000.0),
+        ],
+    })
+
+    inserted = run(gains_snapshotter.snapshot_gains_once(
+        wom_client=client,
+        group_id=1,
+        metrics=["overall"],
+        window_days=7,
+        log=_log,
+        now=NOW,
+    ))
+
+    assert inserted == 2
+    rows = database.read_latest_gains("overall")
+    assert {r["username"] for r in rows} == {"alice", "bob"}
+    # period math: snapshot at NOW, start 7 days earlier
+    assert rows[0]["period_end"] == "2025-01-08 00:00:00"
+    assert rows[0]["period_start"] == "2025-01-01 00:00:00"
+
+
+def test_snapshot_gains_once_idempotent(fake_wom_client, tmp_path):
+    client = fake_wom_client(gains={
+        "overall": [make_gains_entry(make_player("alice"), gained=5000.0)],
+    })
+    kwargs = dict(wom_client=client, group_id=1, metrics=["overall"], window_days=7, log=_log, now=NOW)
+
+    first = run(gains_snapshotter.snapshot_gains_once(**kwargs))
+    second = run(gains_snapshotter.snapshot_gains_once(**kwargs))
+
+    assert first == 1
+    assert second == 0  # same snapshot_time+user+metric → INSERT OR IGNORE
+
+
+def test_snapshot_gains_once_multi_metric(fake_wom_client, tmp_path):
+    client = fake_wom_client(gains={
+        "overall": [make_gains_entry(make_player("alice"), gained=5000.0)],
+        "ehb": [make_gains_entry(make_player("alice"), gained=2.0)],
+    })
+    inserted = run(gains_snapshotter.snapshot_gains_once(
+        wom_client=client, group_id=1, metrics=["overall", "ehb"], window_days=7, log=_log, now=NOW,
+    ))
+    assert inserted == 2
+    assert database.read_latest_gains("ehb")
+    assert database.read_latest_gains("overall")
+
+
+def test_snapshot_gains_once_paginates_beyond_50(fake_wom_client):
+    entries = [make_gains_entry(make_player(f"p{i}"), gained=float(i)) for i in range(120)]
+    client = fake_wom_client(gains={"overall": entries})
+
+    inserted = run(gains_snapshotter.snapshot_gains_once(
+        wom_client=client, group_id=1, metrics=["overall"], window_days=7, log=_log, now=NOW,
+    ))
+    assert inserted == 120
+
+
+def test_collect_gains_leaderboard_sorted(fake_wom_client):
+    client = fake_wom_client(gains={
+        "overall": [
+            make_gains_entry(make_player("low"), gained=10.0),
+            make_gains_entry(make_player("high"), gained=999.0),
+        ],
+    })
+    board = run(gains_snapshotter.collect_gains_leaderboard(
+        wom_client=client, group_id=1, metric_name="overall", window_days=7, log=_log, now=NOW,
+    ))
+    assert board[0] == ("high", 999.0)
+    assert board[1] == ("low", 10.0)

--- a/tests/test_gains_snapshotter.py
+++ b/tests/test_gains_snapshotter.py
@@ -122,7 +122,7 @@ def test_snapshot_gains_once_multi_metric(fake_wom_client, tmp_path):
     assert database.read_latest_gains("overall")
 
 
-def test_snapshot_gains_once_paginates_beyond_50(fake_wom_client):
+def test_snapshot_gains_once_accepts_full_response_beyond_50(fake_wom_client):
     entries = [make_gains_entry(make_player(f"p{i}"), gained=float(i)) for i in range(120)]
     client = fake_wom_client(gains={"overall": entries})
 
@@ -130,6 +130,9 @@ def test_snapshot_gains_once_paginates_beyond_50(fake_wom_client):
         wom_client=client, group_id=1, metrics=["overall"], window_days=7, log=_log, now=NOW,
     ))
     assert inserted == 120
+    assert client.groups.calls == [
+        ("get_gains", gains_snapshotter.resolve_metric("overall"), None, None)
+    ]
 
 
 def test_collect_gains_leaderboard_sorted(fake_wom_client):
@@ -153,7 +156,7 @@ def test_collect_gains_leaderboard_sorted(fake_wom_client):
 def test_snapshot_gains_first_page_failure_writes_nothing(fake_wom_client):
     client = fake_wom_client(gains_errors={("overall", 0): "WOM unavailable"})
 
-    with pytest.raises(RuntimeError, match="overall.*offset 0.*WOM unavailable"):
+    with pytest.raises(RuntimeError, match="overall.*WOM unavailable"):
         run(gains_snapshotter.snapshot_gains_once(
             wom_client=client,
             group_id=1,
@@ -166,24 +169,25 @@ def test_snapshot_gains_first_page_failure_writes_nothing(fake_wom_client):
     assert database.read_latest_gains("overall") == []
 
 
-def test_snapshot_gains_later_page_failure_discards_partial_rows(fake_wom_client):
+def test_snapshot_gains_does_not_request_later_pages(fake_wom_client):
     entries = [make_gains_entry(make_player(f"p{i}"), gained=float(i)) for i in range(75)]
     client = fake_wom_client(
         gains={"overall": entries},
         gains_errors={("overall", 50): "page failed"},
     )
 
-    with pytest.raises(RuntimeError, match="overall.*offset 50.*page failed"):
-        run(gains_snapshotter.snapshot_gains_once(
-            wom_client=client,
-            group_id=1,
-            metrics=["overall"],
-            window_days=7,
-            log=_log,
-            now=NOW,
-        ))
+    inserted = run(gains_snapshotter.snapshot_gains_once(
+        wom_client=client,
+        group_id=1,
+        metrics=["overall"],
+        window_days=7,
+        log=_log,
+        now=NOW,
+    ))
 
-    assert database.read_latest_gains("overall") == []
+    assert inserted == 75
+    assert len(database.read_latest_gains("overall", limit=100)) == 75
+    assert len(client.groups.calls) == 1
 
 
 def test_snapshot_gains_multi_metric_failure_is_atomic(fake_wom_client):
@@ -192,7 +196,7 @@ def test_snapshot_gains_multi_metric_failure_is_atomic(fake_wom_client):
         gains_errors={("ehb", 0): "EHB failed"},
     )
 
-    with pytest.raises(RuntimeError, match="ehb.*offset 0.*EHB failed"):
+    with pytest.raises(RuntimeError, match="ehb.*EHB failed"):
         run(gains_snapshotter.snapshot_gains_once(
             wom_client=client,
             group_id=1,
@@ -223,7 +227,7 @@ def test_snapshot_gains_requires_at_least_one_valid_metric(fake_wom_client):
 def test_live_gains_leaderboard_propagates_api_failure(fake_wom_client):
     client = fake_wom_client(gains_errors={("overall", 0): "live failed"})
 
-    with pytest.raises(RuntimeError, match="overall.*offset 0.*live failed"):
+    with pytest.raises(RuntimeError, match="overall.*live failed"):
         run(gains_snapshotter.collect_gains_leaderboard(
             wom_client=client,
             group_id=1,

--- a/tests/test_rank_utils.py
+++ b/tests/test_rank_utils.py
@@ -29,6 +29,11 @@ def tmp_ranks_ini(tmp_path, monkeypatch):
         f.write("0-99 = Bronze\n")
         f.write("100-199 = Silver\n")
         f.write("200+ = Gold\n")
+        f.write("\n")
+        f.write("[Skilling Ranking]\n")
+        f.write("0-99 = Wood\n")
+        f.write("100-199 = Stone\n")
+        f.write("200+ = Steel\n")
 
     original_read = configparser.ConfigParser.read
 

--- a/tests/test_rank_utils_ehp.py
+++ b/tests/test_rank_utils_ehp.py
@@ -1,6 +1,7 @@
 """Tests for the EHP (skilling) rank ladder — Feature 2."""
 
 import json
+import os
 
 from python.utils import rank_utils
 
@@ -50,9 +51,57 @@ def test_next_rank_ehp_max(tmp_path, monkeypatch, tmp_ranks_ini):
     assert rank_utils.next_rank_ehp("player") == "Max Rank Achieved 👑"
 
 
+def test_production_ehp_rank_boundaries():
+    ranks_file = os.path.join(os.path.dirname(rank_utils.RANKS_INI), "ranks.ini.example")
+
+    assert rank_utils.get_ehp_rank(0, ranks_file) == "Novice"
+    assert rank_utils.get_ehp_rank(99.99, ranks_file) == "Novice"
+    assert rank_utils.get_ehp_rank(100, ranks_file) == "Apprentice"
+    assert rank_utils.get_ehp_rank(500, ranks_file) == "Adept"
+    assert rank_utils.get_ehp_rank(1000, ranks_file) == "Expert"
+    assert rank_utils.get_ehp_rank(1500, ranks_file) == "Master"
+    assert rank_utils.get_ehp_rank(2000, ranks_file) == "Master"
+
+
+def test_next_rank_for_missing_section_is_unknown(tmp_ranks_ini):
+    assert rank_utils._next_rank_for("Stone", "No Such Section", "EHP") == "Unknown"
+
+
+def test_next_rank_for_unmatched_rank_is_unknown(tmp_ranks_ini):
+    assert rank_utils._next_rank_for("Unknown", "Skilling Ranking", "EHP") == "Unknown"
+
+
 # ---------------------------------------------------------------------------
 # save_ranks: EHP field preservation
 # ---------------------------------------------------------------------------
+
+def test_merge_manual_rank_update_preserves_ehp_and_future_fields():
+    existing = {
+        "last_ehb": 42,
+        "rank": "Bronze",
+        "last_ehp": 120,
+        "ehp_rank": "Stone",
+        "future_field": "keep-me",
+    }
+
+    result = rank_utils.merge_manual_rank_update(existing, 12, "Wood")
+
+    assert result == {
+        "last_ehb": 12,
+        "rank": "Wood",
+        "last_ehp": 120,
+        "ehp_rank": "Stone",
+        "future_field": "keep-me",
+    }
+    assert existing["last_ehb"] == 42
+
+
+def test_merge_manual_rank_update_does_not_add_ehp_to_legacy_row():
+    result = rank_utils.merge_manual_rank_update(
+        {"last_ehb": 42, "rank": "Bronze"}, 50, "Silver"
+    )
+
+    assert result == {"last_ehb": 50, "rank": "Silver"}
 
 def test_save_ranks_preserves_ehp_fields(tmp_path, monkeypatch):
     ranks_file = tmp_path / "player_ranks.json"
@@ -60,6 +109,17 @@ def test_save_ranks_preserves_ehp_fields(tmp_path, monkeypatch):
     monkeypatch.setattr(rank_utils, "upsert_players", lambda players: None)
 
     data = {"player": {"last_ehb": 42, "rank": "Bronze", "last_ehp": 120, "ehp_rank": "Stone"}}
+    rank_utils.save_ranks(data)
+
+    assert json.loads(ranks_file.read_text()) == data
+
+
+def test_save_ranks_preserves_future_fields(tmp_path, monkeypatch):
+    ranks_file = tmp_path / "player_ranks.json"
+    monkeypatch.setattr(rank_utils, "RANKS_FILE", str(ranks_file))
+    monkeypatch.setattr(rank_utils, "upsert_players", lambda players: None)
+    data = {"player": {"last_ehb": 42, "rank": "Bronze", "future_field": "keep-me"}}
+
     rank_utils.save_ranks(data)
 
     assert json.loads(ranks_file.read_text()) == data

--- a/tests/test_rank_utils_ehp.py
+++ b/tests/test_rank_utils_ehp.py
@@ -1,0 +1,143 @@
+"""Tests for the EHP (skilling) rank ladder — Feature 2."""
+
+import json
+
+from python.utils import rank_utils
+
+
+# ---------------------------------------------------------------------------
+# Consolidated parser: EHP section
+# ---------------------------------------------------------------------------
+
+def test_get_rank_for_value_ehp_section(tmp_ranks_ini):
+    assert rank_utils.get_rank_for_value(50, "Skilling Ranking") == "Wood"
+    assert rank_utils.get_rank_for_value(150, "Skilling Ranking") == "Stone"
+    assert rank_utils.get_rank_for_value(500, "Skilling Ranking") == "Steel"
+
+
+def test_get_ehp_rank_wrapper(tmp_ranks_ini):
+    assert rank_utils.get_ehp_rank(0) == "Wood"
+    assert rank_utils.get_ehp_rank(100) == "Stone"
+
+
+def test_get_rank_thresholds_unknown_section_returns_empty(tmp_ranks_ini):
+    assert rank_utils.get_rank_thresholds("No Such Section") == []
+
+
+def test_get_rank_for_value_boundary_semantics(tmp_ranks_ini):
+    # lower bound inclusive, upper exclusive; the fixture's 0-99/100-199 ranges
+    # leave a gap at exactly 99 which resolves to Unknown.
+    assert rank_utils.get_rank_for_value(98, "Skilling Ranking") == "Wood"
+    assert rank_utils.get_rank_for_value(100, "Skilling Ranking") == "Stone"
+    assert rank_utils.get_rank_for_value(99, "Skilling Ranking") == "Unknown"
+
+
+def test_next_rank_ehp(tmp_path, monkeypatch, tmp_ranks_ini):
+    ranks_data = {"player": {"last_ehb": 10, "rank": "Bronze", "last_ehp": 150, "ehp_rank": "Stone"}}
+    ranks_file = tmp_path / "player_ranks.json"
+    ranks_file.write_text(json.dumps(ranks_data))
+    monkeypatch.setattr(rank_utils, "RANKS_FILE", str(ranks_file))
+
+    assert rank_utils.next_rank_ehp("player") == "Steel at 200 EHP"
+
+
+def test_next_rank_ehp_max(tmp_path, monkeypatch, tmp_ranks_ini):
+    ranks_data = {"player": {"last_ehb": 10, "rank": "Bronze", "last_ehp": 300, "ehp_rank": "Steel"}}
+    ranks_file = tmp_path / "player_ranks.json"
+    ranks_file.write_text(json.dumps(ranks_data))
+    monkeypatch.setattr(rank_utils, "RANKS_FILE", str(ranks_file))
+
+    assert rank_utils.next_rank_ehp("player") == "Max Rank Achieved 👑"
+
+
+# ---------------------------------------------------------------------------
+# save_ranks: EHP field preservation
+# ---------------------------------------------------------------------------
+
+def test_save_ranks_preserves_ehp_fields(tmp_path, monkeypatch):
+    ranks_file = tmp_path / "player_ranks.json"
+    monkeypatch.setattr(rank_utils, "RANKS_FILE", str(ranks_file))
+    monkeypatch.setattr(rank_utils, "upsert_players", lambda players: None)
+
+    data = {"player": {"last_ehb": 42, "rank": "Bronze", "last_ehp": 120, "ehp_rank": "Stone"}}
+    rank_utils.save_ranks(data)
+
+    assert json.loads(ranks_file.read_text()) == data
+
+
+def test_save_ranks_omits_ehp_for_pre_ehp_rows(tmp_path, monkeypatch):
+    """Rows without EHP keys round-trip byte-for-byte (backward compatible)."""
+    ranks_file = tmp_path / "player_ranks.json"
+    monkeypatch.setattr(rank_utils, "RANKS_FILE", str(ranks_file))
+    monkeypatch.setattr(rank_utils, "upsert_players", lambda players: None)
+
+    data = {"player": {"last_ehb": 42, "rank": "Bronze"}}
+    rank_utils.save_ranks(data)
+
+    assert json.loads(ranks_file.read_text()) == {"player": {"last_ehb": 42, "rank": "Bronze"}}
+
+
+def test_save_ranks_syncs_on_ehp_change(tmp_path, monkeypatch):
+    ranks_file = tmp_path / "player_ranks.json"
+    ranks_file.write_text(json.dumps({"player": {"last_ehb": 42, "rank": "Bronze", "last_ehp": 100, "ehp_rank": "Stone"}}))
+    monkeypatch.setattr(rank_utils, "RANKS_FILE", str(ranks_file))
+
+    calls = []
+    monkeypatch.setattr(rank_utils, "upsert_players", lambda players: calls.append(players))
+
+    # EHB unchanged, EHP changed → must still sync
+    rank_utils.save_ranks({"player": {"last_ehb": 42, "rank": "Bronze", "last_ehp": 130, "ehp_rank": "Stone"}})
+
+    assert calls and "player" in calls[0]
+
+
+# ---------------------------------------------------------------------------
+# compute_member_update: independent EHB / EHP evaluation
+# ---------------------------------------------------------------------------
+
+def test_compute_member_update_ehb_increase():
+    result = rank_utils.compute_member_update(
+        {"last_ehb": 10, "rank": "Bronze"}, ehb=15, rank="Silver"
+    )
+    assert result["ehb_increase"] is True
+    assert result["entry"]["last_ehb"] == 15
+    assert result["entry"]["rank"] == "Silver"
+
+
+def test_compute_member_update_stale_rank_correction():
+    result = rank_utils.compute_member_update(
+        {"last_ehb": 10, "rank": "Unknown"}, ehb=10, rank="Bronze"
+    )
+    assert result["ehb_increase"] is False
+    assert result["entry"]["rank"] == "Bronze"
+
+
+def test_compute_member_update_ehp_only_increase_not_swallowed():
+    """Flat EHB but rising EHP must still register an EHP increase."""
+    result = rank_utils.compute_member_update(
+        {"last_ehb": 10, "rank": "Bronze", "last_ehp": 100, "ehp_rank": "Stone"},
+        ehb=10,
+        rank="Bronze",
+        ehp=250,
+        ehp_rank="Steel",
+        track_ehp=True,
+    )
+    assert result["ehb_increase"] is False
+    assert result["ehp_increase"] is True
+    assert result["entry"]["last_ehp"] == 250
+    assert result["entry"]["ehp_rank"] == "Steel"
+
+
+def test_compute_member_update_ehp_untracked_leaves_ehp_alone():
+    result = rank_utils.compute_member_update(
+        {"last_ehb": 10, "rank": "Bronze", "last_ehp": 100, "ehp_rank": "Stone"},
+        ehb=12,
+        rank="Bronze",
+        ehp=999,
+        ehp_rank="Steel",
+        track_ehp=False,
+    )
+    assert result["ehp_increase"] is False
+    # untouched EHP fields preserved from last_data
+    assert result["entry"]["last_ehp"] == 100
+    assert result["entry"]["ehp_rank"] == "Stone"

--- a/tests/test_report_generators.py
+++ b/tests/test_report_generators.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 import pytest
 
 from python.weeklyupdater import weekly_reporter
+from python.weeklyupdater import monthly_reporter
 from python.weeklyupdater import yearly_reporter
 
 
@@ -83,6 +84,46 @@ def test_most_recent_year_end_raises_for_naive_datetime():
 
 
 # ---------------------------------------------------------------------------
+# monthly_reporter — completed calendar-month boundaries and output
+# ---------------------------------------------------------------------------
+
+
+def test_most_recent_month_end_uses_current_month_boundary_after_noon():
+    now = datetime(2025, 6, 15, 8, 0, tzinfo=timezone.utc)
+    assert monthly_reporter.most_recent_month_end(now) == datetime(
+        2025, 6, 1, 12, 0, tzinfo=timezone.utc
+    )
+
+
+def test_most_recent_month_end_rolls_back_before_boundary():
+    now = datetime(2025, 6, 1, 11, 59, tzinfo=timezone.utc)
+    assert monthly_reporter.most_recent_month_end(now) == datetime(
+        2025, 5, 1, 12, 0, tzinfo=timezone.utc
+    )
+
+
+def test_monthly_report_includes_totals_and_ehp_leaders():
+    def gain(name, value):
+        player = types.SimpleNamespace(display_name=name)
+        return types.SimpleNamespace(player=player, data=types.SimpleNamespace(gained=value))
+
+    lines = monthly_reporter._build_report_lines(
+        start_date=datetime(2025, 5, 1, 12, 0, tzinfo=timezone.utc),
+        end_date=datetime(2025, 6, 1, 12, 0, tzinfo=timezone.utc),
+        overall_gains=[gain("Alice", 2_000_000)],
+        ehb_gains=[gain("Bob", 12.5)],
+        ehp_gains=[gain("Carol", 8.25)],
+        sailing_gains=[],
+        name_changes=[],
+        achievements=[],
+        player_name_map={1: "Alice", 2: "Bob"},
+    )
+    report = "\n".join(lines)
+    assert "Monthly Report - May 2025" in report
+    assert "Group XP gained: 2,000,000 xp" in report
+    assert "Carol (+8.25 EHP)" in report
+
+
 # weekly_reporter._chunk_messages
 # ---------------------------------------------------------------------------
 
@@ -220,6 +261,31 @@ def test_build_report_lines_includes_ehb_top_gainers():
     assert "Alice" in combined
     assert "12.50" in combined
     assert "Bob" in combined
+
+
+def test_build_report_lines_includes_weekly_totals_and_ehp_gainers():
+    start = datetime(2025, 6, 1, 18, 0, tzinfo=timezone.utc)
+    end = datetime(2025, 6, 8, 18, 0, tzinfo=timezone.utc)
+    lines = weekly_reporter._build_report_lines(
+        start_date=start,
+        end_date=end,
+        overall_top=("Alice", 2_000_000),
+        ehb_top=[],
+        sailing_top=None,
+        name_changes=[],
+        achievements=[],
+        player_name_map={1: "Alice", 2: "Bob"},
+        total_xp=3_000_000,
+        active_members=2,
+        total_ehb=10.5,
+        ehp_top=[("Bob", 7.25)],
+        total_ehp=12.0,
+    )
+    report = "\n".join(lines)
+    assert "Week at a glance" in report
+    assert "Group XP gained: 3,000,000 xp" in report
+    assert "Active gainers: 2/2 members" in report
+    assert "Bob (+7.25 EHP)" in report
 
 
 def test_build_report_lines_name_changes_rendered():

--- a/tests/test_web_routers.py
+++ b/tests/test_web_routers.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 
 from web.services.bot_state import BotState
 from web.routers import admin, charts, dashboard, group, players
+from utils import database
 
 
 # ---------------------------------------------------------------------------
@@ -307,6 +308,50 @@ def test_player_history_empty_for_unknown_player(monkeypatch, sample_csv_file):
 
     assert response.status_code == 200
     assert response.json() == []
+
+
+# ---------------------------------------------------------------------------
+# GET /charts/api/ehp-history + /charts/api/gains-history
+# ---------------------------------------------------------------------------
+
+def test_ehp_history_endpoint_returns_list():
+    """EHP history endpoint returns the persisted rows as JSON."""
+    database.log_ehp_history("alice", 120.0, timestamp="2025-01-01 12:00:00")
+    database.log_ehp_history("alice", 130.0, timestamp="2025-02-01 12:00:00")
+
+    with TestClient(_make_app(_make_bot_state())) as client:
+        data = client.get("/charts/api/ehp-history?player=alice").json()
+
+    assert data == [
+        {"timestamp": "2025-01-01 12:00:00", "ehp": 120.0},
+        {"timestamp": "2025-02-01 12:00:00", "ehp": 130.0},
+    ]
+
+
+def test_gains_history_endpoint_returns_list():
+    """Gains history endpoint returns persisted snapshots for a player+metric."""
+    database.log_gains_snapshot([
+        {"snapshot_time": "2025-01-08 00:00:00", "period_start": "2025-01-01 00:00:00",
+         "period_end": "2025-01-08 00:00:00", "username": "alice", "metric": "overall", "gained": 5000.0},
+    ])
+
+    with TestClient(_make_app(_make_bot_state())) as client:
+        data = client.get("/charts/api/gains-history?player=alice&metric=overall").json()
+
+    assert data == [{"timestamp": "2025-01-08 00:00:00", "gained": 5000.0}]
+
+
+def test_players_page_shows_ehp_columns(monkeypatch, sample_players):
+    """Players table renders the Skill Rank / EHP columns."""
+    from web.services import ranks_service
+    monkeypatch.setattr(ranks_service, "load_ranks", lambda: sample_players)
+
+    with TestClient(_make_app(_make_bot_state())) as client:
+        response = client.get("/players/")
+
+    assert response.status_code == 200
+    assert "Skill Rank" in response.text
+    assert "Adept" in response.text  # silver_sam's ehp_rank from the fixture
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add optional EHP tracking alongside existing EHB rank updates, including persistence, Discord notifications, and web visibility.
- Introduce gains snapshot collection and live `/gains` support, with SQLite-backed history and dashboard charts.
- Add monthly report scheduling and web rendering, plus related updates to weekly and yearly report flows.
- Update configuration, docs, and Docker networking defaults for the new channels and settings.
- Expand test coverage for database migrations, gains snapshotting, rank utilities, report generation, and web routers.

## Testing
- Not run locally in this branch review.
- Added/updated tests cover EHP rank transitions and state preservation in `tests/test_rank_utils_ehp.py`.
- Added/updated tests cover gains pagination, metric resolution, snapshot atomicity, and live leaderboard formatting in `tests/test_gains_snapshotter.py`.
- Added/updated tests cover SQLite persistence and HTTP endpoints in `tests/test_database.py` and `tests/test_web_routers.py`.
- Added/updated tests cover weekly/yearly/monthly report generation in `tests/test_report_generators.py`.