### PR TITLE
Use SQLite for persistent rank snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,10 +40,10 @@ Shared bot/web state lives in `python/web/services/bot_state.py` (`BotState`). T
 1. Fetch group member details from WOM.
 2. Calculate EHB rank from `[Group Ranking]`; when `track_ehp = true`, calculate EHP rank from `[Skilling Ranking]`.
 3. Use `rank_utils.compute_member_update()` to evaluate EHB and EHP independently and merge them without discarding other per-player fields.
-4. On EHB increase, notify Discord, append to the legacy EHB CSV when enabled, and update JSON/SQLite.
+4. On EHB increase, notify Discord, append to the legacy EHB CSV when enabled, and update SQLite.
 5. On EHP increase, notify Discord with an EHP label and append to SQLite `ehp_history`.
 
-`python/utils/player_ranks.json` remains the rank snapshot used by the bot and web UI. Entries always contain `last_ehb` and `rank`; EHP-enabled entries also contain `last_ehp` and `ehp_rank`. `save_ranks()` mirrors changed snapshots into SQLite while preserving optional/future fields. Manual `/update` changes only the EHB fields.
+The SQLite `players` table is the authoritative rank snapshot used by the bot and web UI. Rows always contain `last_ehb` and `rank`; EHP-enabled snapshots also surface `last_ehp` and `ehp_rank`. On an empty database, `load_ranks()` imports a legacy `python/utils/player_ranks.json` snapshot when present, then falls back to the legacy EHB CSV. Manual `/update` changes only the EHB fields.
 
 ### Gains tracking
 
@@ -79,7 +79,7 @@ The dashboard now exposes EHP and gains data:
 |---|---|
 | `python/WOM.py` | Entry point, bot lifecycle, rank checks, and periodic task startup |
 | `python/utils/commands.py` | Discord slash commands, including `/ehpladder` and live `/gains` |
-| `python/utils/rank_utils.py` | Shared EHB/EHP threshold parsing, state merging, JSON persistence, and next-rank helpers |
+| `python/utils/rank_utils.py` | Shared EHB/EHP threshold parsing, state merging, legacy snapshot migration, and next-rank helpers |
 | `python/utils/database.py` | SQLite schema/migrations and EHB, EHP, boss, gains, and player persistence |
 | `python/gainstracker/` | WOM gains collection, formatting, persistence, and scheduler |
 | `python/utils/log_csv.py` | Legacy append-only EHB CSV logging |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Discord bot that integrates with the Wise Old Man API to track EHB and optiona
 - Group refresh via Wise Old Man update-all, plus periodic refresh.
 - Weekly, monthly, and yearly report generation (auto-scheduled or on-demand).
 - Local SQLite storage bootstrapped automatically on startup.
-- CSV logging with auto-bootstrap of ranks from `ehb_log.csv` when JSON storage is missing.
+- CSV logging with legacy rank bootstrap into SQLite when no player snapshots exist.
 - FastAPI web dashboard (players, reports, charts, admin, group pages).
 - Docker support with persisted CSV logs and SQLite data — runs bot + web dashboard on port 8080.
 
@@ -147,7 +147,8 @@ Reports can be scheduled automatically (when channel IDs are set) or run on dema
 - Set `EHB_LOG_PATH` to override the CSV location (useful in Docker).
 - SQLite data is stored in `python/database.db` by default.
 - Set `WOM_DATABASE_PATH` to override the SQLite location. In Docker this defaults to `/app/data/database.db`.
-- `player_ranks.json` stores the latest rank snapshot and is auto-bootstrapped from the CSV if missing.
+- The SQLite `players` table stores the latest EHB/EHP rank snapshot used by the bot and dashboard.
+- Existing `player_ranks.json` data is imported automatically only when the `players` table is empty; the CSV is the final legacy fallback.
 
 ## Docker
 Build and run:

--- a/python/utils/database.py
+++ b/python/utils/database.py
@@ -107,6 +107,7 @@ def init_database(db_path: str | None = None) -> str:
                 "last_ehp": "REAL NOT NULL DEFAULT 0",
                 "ehp_rank": "TEXT NOT NULL DEFAULT 'Unknown'",
                 "total_xp": "INTEGER",
+                "snapshot_initialized": "INTEGER NOT NULL DEFAULT 0",
                 # Feature 3 — inactivity / status detection
                 "player_id": "INTEGER",
                 "wom_status": "TEXT",
@@ -115,6 +116,20 @@ def init_database(db_path: str | None = None) -> str:
                 "last_progressed_at": "TEXT",
                 "status_captured_at": "TEXT",
             },
+        )
+        # Existing databases predate the explicit snapshot marker. Infer it
+        # from non-default rank data without marking status-only player rows.
+        conn.execute(
+            """
+            UPDATE players
+            SET snapshot_initialized = 1
+            WHERE snapshot_initialized = 0
+              AND (
+                  last_ehb != 0 OR rank != 'Unknown'
+                  OR last_ehp != 0 OR ehp_rank != 'Unknown'
+                  OR total_xp IS NOT NULL
+              )
+            """
         )
 
         # Feature 2 — EHP history (mirror of ehb_history)
@@ -256,15 +271,17 @@ def upsert_players(players: dict[str, dict], db_path: str | None = None) -> None
         conn.executemany(
             """
             INSERT INTO players (
-                username, last_ehb, rank, last_ehp, ehp_rank, total_xp, updated_at
+                username, last_ehb, rank, last_ehp, ehp_rank, total_xp,
+                snapshot_initialized, updated_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, 1, ?)
             ON CONFLICT(username) DO UPDATE SET
                 last_ehb = excluded.last_ehb,
                 rank = excluded.rank,
                 last_ehp = excluded.last_ehp,
                 ehp_rank = excluded.ehp_rank,
                 total_xp = COALESCE(excluded.total_xp, players.total_xp),
+                snapshot_initialized = 1,
                 updated_at = excluded.updated_at
             """,
             [
@@ -281,6 +298,33 @@ def upsert_players(players: dict[str, dict], db_path: str | None = None) -> None
             ],
         )
         conn.commit()
+
+
+def read_player_snapshots(db_path: str | None = None) -> dict[str, dict]:
+    """Return the latest persisted EHB, EHP, and total-XP state by username."""
+    resolved_path = init_database(db_path)
+    with closing(connect_db(resolved_path)) as conn:
+        rows = conn.execute(
+            """
+            SELECT username, last_ehb, rank, last_ehp, ehp_rank, total_xp
+            FROM players
+            WHERE snapshot_initialized = 1
+            """
+        ).fetchall()
+
+    snapshots = {}
+    for row in rows:
+        snapshot = {
+            "last_ehb": row["last_ehb"],
+            "rank": row["rank"],
+        }
+        if row["last_ehp"] != 0 or row["ehp_rank"] != "Unknown":
+            snapshot["last_ehp"] = row["last_ehp"]
+            snapshot["ehp_rank"] = row["ehp_rank"]
+        if row["total_xp"] is not None:
+            snapshot["total_xp"] = row["total_xp"]
+        snapshots[row["username"]] = snapshot
+    return snapshots
 
 
 def upsert_player_status(rows: list[dict], db_path: str | None = None) -> None:

--- a/python/utils/rank_utils.py
+++ b/python/utils/rank_utils.py
@@ -1,10 +1,10 @@
 import json
 import os
 import configparser
-from .database import upsert_players
+from .database import read_player_snapshots, upsert_players
 from .log_csv import load_latest_ehb_from_csv
 
-# JSON file for storing player ranks
+# Legacy JSON snapshot retained only as a one-time migration source.
 RANKS_FILE = os.path.join(os.path.dirname(__file__), 'player_ranks.json')
 RANKS_INI = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'ranks.ini')
 
@@ -84,31 +84,44 @@ def _bootstrap_ranks_from_csv():
     return ranks_data
 
 def load_ranks():
-    """Load ranks from a JSON file."""
+    """Load rank snapshots from SQLite, importing legacy storage when empty."""
+    persisted = read_player_snapshots()
+    if persisted:
+        return persisted
+
     if os.path.exists(RANKS_FILE):
         try:
             with open(RANKS_FILE, 'r') as f:
-                return json.load(f)
+                legacy_data = json.load(f)
 
         except (json.JSONDecodeError, ValueError):
-            print(f"Error: {RANKS_FILE} is empty or corrupted. Resetting data.")
-            return _bootstrap_ranks_from_csv()
-    return _bootstrap_ranks_from_csv()
+            print(f"Error: {RANKS_FILE} is empty or corrupted. Trying legacy CSV.")
+        else:
+            if legacy_data:
+                sanitized_data = {
+                    username: _sanitize_player_entry(pdata)
+                    for username, pdata in legacy_data.items()
+                }
+                upsert_players(sanitized_data)
+                print(f"Imported legacy rank snapshots from {RANKS_FILE} into SQLite.")
+                return sanitized_data
+
+    legacy_data = _bootstrap_ranks_from_csv()
+    if legacy_data:
+        upsert_players(legacy_data)
+        print("Imported legacy EHB snapshots from CSV into SQLite.")
+    return legacy_data
 
 def _sanitize_player_entry(pdata):
-    """Return a persisted player entry, preserving optional and future fields.
-
-    Preserving optional keys conditionally keeps the JSON backward-compatible:
-    legacy rows round-trip without fabricated values, while tracked rows retain
-    their EHP and total-XP fields.
-    """
+    """Return the supported rank fields for SQLite persistence."""
     pdata = pdata or {}
-    entry = dict(pdata)
-    entry.setdefault("last_ehb", 0)
-    entry.setdefault("rank", "Unknown")
+    entry = {
+        "last_ehb": pdata.get("last_ehb", 0),
+        "rank": pdata.get("rank", "Unknown"),
+    }
     if "last_ehp" in pdata or "ehp_rank" in pdata:
-        entry.setdefault("last_ehp", 0)
-        entry.setdefault("ehp_rank", "Unknown")
+        entry["last_ehp"] = pdata.get("last_ehp", 0)
+        entry["ehp_rank"] = pdata.get("ehp_rank", "Unknown")
     if "total_xp" in pdata:
         total_xp = pdata.get("total_xp")
         entry["total_xp"] = int(total_xp) if total_xp is not None else None
@@ -124,39 +137,13 @@ def merge_manual_rank_update(last_data: dict, ehb: float, rank: str) -> dict:
 
 
 def save_ranks(data):
-    """Save ranks to ``player_ranks.json`` and sync the latest snapshot to SQLite."""
+    """Persist the latest sanitized rank snapshot to SQLite."""
     sanitized_data = {
         username: _sanitize_player_entry(pdata)
         for username, pdata in data.items()
     }
 
-    # Load existing data to compare EHB / EHP / total XP values
-    old_data = {}
-    if os.path.exists(RANKS_FILE):
-        try:
-            with open(RANKS_FILE, "r") as f:
-                old_data = json.load(f)
-        except (json.JSONDecodeError, ValueError):
-            old_data = {}
-
-    # Write the new data to disk
-    with open(RANKS_FILE, "w") as f:
-        json.dump(sanitized_data, f, indent=4)
-
-    try:
-        changed_rows = {
-            username: pdata
-            for username, pdata in sanitized_data.items()
-            if old_data.get(username, {}).get("last_ehb") != pdata.get("last_ehb")
-            or old_data.get(username, {}).get("rank") != pdata.get("rank")
-            or old_data.get(username, {}).get("last_ehp") != pdata.get("last_ehp")
-            or old_data.get(username, {}).get("ehp_rank") != pdata.get("ehp_rank")
-            or old_data.get(username, {}).get("total_xp") != pdata.get("total_xp")
-        }
-        if changed_rows:
-            upsert_players(changed_rows)
-    except Exception as e:
-        print(f"Error updating SQLite player snapshot: {e}")
+    upsert_players(sanitized_data)
 
 def _next_rank_for(current_rank, section, unit_label):
     """Return the next-rank description for a current rank within a ranks section."""

--- a/rmap.md
+++ b/rmap.md
@@ -14,7 +14,7 @@ A reference document for a repo-wide refactor. Use this as a living guide — ch
 
 **Tech stack**: discord.py, wom.py, aiohttp, FastAPI, Uvicorn, Jinja2, SQLite, pytest
 
-**Data stores**: `player_ranks.json` (local JSON), `ehb_log.csv` (append-only log), `database.db` (local SQLite)
+**Data stores**: `database.db` (authoritative SQLite snapshots/history), `ehb_log.csv` (legacy append-only EHB log), and `player_ranks.json` (legacy one-time migration source)
 
 ---
 
@@ -28,7 +28,7 @@ A reference document for a repo-wide refactor. Use this as a living guide — ch
 | `log` | `log(message: str)` | Timestamped print + optional GUI queue push |
 | `get_rank` | `get_rank(ehb, ranks_file)` | **DUPLICATE** — same logic as `rank_utils._get_rank_for_ehb()`. Delete this. |
 | `on_ready` | Discord event | Syncs slash commands, starts WOM session, spawns all background tasks |
-| `check_for_rank_changes` | `@tasks.loop` async | Core loop: fetch WOM group → compare EHB → log CSV → update JSON → post Discord |
+| `check_for_rank_changes` | `@tasks.loop` async | Core loop: fetch WOM group → compare EHB/EHP → log history → update SQLite → post Discord |
 | `list_all_members_and_ranks` | `async def` | Fetch all members, format ranked table, chunk to Discord 2000-char limit |
 | `refresh_group_data` | `async def` | POST to WOM update-all API with passcode; handles 200/401/429 responses |
 | `refresh_group_task` | `@tasks.loop` async | Periodic group refresh (default every 172800s / 48h) |
@@ -44,9 +44,9 @@ A reference document for a repo-wide refactor. Use this as a living guide — ch
 
 | Function | Signature | Purpose |
 |---|---|---|
-| `_bootstrap_ranks_from_csv` | `() -> None` | Seeds `player_ranks.json` from `ehb_log.csv` when JSON is missing |
-| `load_ranks` | `() -> dict` | Reads the latest rank snapshot JSON |
-| `save_ranks` | `(data: dict) -> None` | Writes JSON; syncs changed player snapshot rows to SQLite |
+| `_bootstrap_ranks_from_csv` | `() -> dict` | Builds legacy EHB snapshots from `ehb_log.csv` when SQLite and JSON are empty |
+| `load_ranks` | `() -> dict` | Reads SQLite snapshots, importing legacy JSON/CSV only when the table is empty |
+| `save_ranks` | `(data: dict) -> None` | Writes the latest player snapshot to SQLite |
 | `next_rank` | `(username: str) -> str` | Returns formatted "Rank at X EHB" progress string |
 | `_get_rank_for_ehb` | `(ehb: float) -> str` | Parses `ranks.ini`, returns rank name — **re-reads file every call** (no cache) |
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -103,6 +103,7 @@ def test_init_database_migrates_pre_existing_players_table(tmp_path):
         "last_ehp",
         "ehp_rank",
         "total_xp",
+        "snapshot_initialized",
         "player_id",
         "wom_status",
         "last_changed_at",
@@ -288,3 +289,39 @@ def test_achievement_dedup_key_includes_threshold(tmp_path):
         db_path=str(db_path),
     )
     assert inserted == 2
+
+
+def test_read_player_snapshots_returns_persisted_rank_state(tmp_path):
+    db_path = tmp_path / "database.db"
+    database.upsert_players(
+        {
+            "alice": {
+                "last_ehb": 42.5,
+                "rank": "Silver",
+                "last_ehp": 300.0,
+                "ehp_rank": "Adept",
+                "total_xp": 123456789,
+            }
+        },
+        db_path=str(db_path),
+    )
+
+    assert database.read_player_snapshots(db_path=str(db_path)) == {
+        "alice": {
+            "last_ehb": 42.5,
+            "rank": "Silver",
+            "last_ehp": 300.0,
+            "ehp_rank": "Adept",
+            "total_xp": 123456789,
+        }
+    }
+
+
+def test_read_player_snapshots_ignores_status_only_rows(tmp_path):
+    db_path = tmp_path / "database.db"
+    database.upsert_player_status(
+        [{"username": "status-only", "wom_status": "active"}],
+        db_path=str(db_path),
+    )
+
+    assert database.read_player_snapshots(db_path=str(db_path)) == {}

--- a/tests/test_rank_utils.py
+++ b/tests/test_rank_utils.py
@@ -61,6 +61,90 @@ def test_load_ranks_preserves_json_payload(tmp_path, monkeypatch):
     assert result == data
 
 
+def test_load_ranks_restores_ehp_baseline_from_sqlite_after_restart(tmp_path, monkeypatch):
+    """A missing container-local JSON file must not reset persisted EHP state."""
+    ranks_file = tmp_path / "missing-player-ranks.json"
+    monkeypatch.setattr(rank_utils, "RANKS_FILE", str(ranks_file))
+    rank_utils.upsert_players(
+        {
+            "alice": {
+                "last_ehb": 42.5,
+                "rank": "Silver",
+                "last_ehp": 300.0,
+                "ehp_rank": "Adept",
+                "total_xp": 123456789,
+            }
+        }
+    )
+
+    ranks = rank_utils.load_ranks()
+    update = rank_utils.compute_member_update(
+        ranks["alice"],
+        ehb=42.5,
+        rank="Silver",
+        ehp=300.0,
+        ehp_rank="Adept",
+        track_ehp=True,
+        total_xp=123456789,
+    )
+
+    assert update["ehp_increase"] is False
+    assert update["ehp_old_rank"] == "Adept"
+    assert not ranks_file.exists()
+
+
+def test_load_ranks_migrates_legacy_json_when_database_is_empty(tmp_path, monkeypatch):
+    legacy = {
+        "alice": {
+            "last_ehb": 42.5,
+            "rank": "Silver",
+            "last_ehp": 300.0,
+            "ehp_rank": "Adept",
+        }
+    }
+    ranks_file = tmp_path / "player_ranks.json"
+    ranks_file.write_text(json.dumps(legacy))
+    monkeypatch.setattr(rank_utils, "RANKS_FILE", str(ranks_file))
+
+    assert rank_utils.load_ranks() == legacy
+
+    ranks_file.unlink()
+    assert rank_utils.load_ranks() == legacy
+
+
+def test_status_only_database_rows_do_not_block_legacy_migration(tmp_path, monkeypatch):
+    from python.utils.database import upsert_player_status
+
+    upsert_player_status([{"username": "status-only", "wom_status": "active"}])
+    legacy = {"alice": {"last_ehb": 42.5, "rank": "Silver"}}
+    ranks_file = tmp_path / "player_ranks.json"
+    ranks_file.write_text(json.dumps(legacy))
+    monkeypatch.setattr(rank_utils, "RANKS_FILE", str(ranks_file))
+
+    assert rank_utils.load_ranks() == legacy
+
+
+def test_save_ranks_does_not_recreate_legacy_json(tmp_path, monkeypatch):
+    ranks_file = tmp_path / "player_ranks.json"
+    monkeypatch.setattr(rank_utils, "RANKS_FILE", str(ranks_file))
+
+    data = {"alice": {"last_ehb": 42.5, "rank": "Silver"}}
+    rank_utils.save_ranks(data)
+
+    assert rank_utils.load_ranks()["alice"]["last_ehb"] == 42.5
+    assert not ranks_file.exists()
+
+
+def test_save_ranks_propagates_sqlite_failures(monkeypatch):
+    def fail_write(_players):
+        raise OSError("database is read-only")
+
+    monkeypatch.setattr(rank_utils, "upsert_players", fail_write)
+
+    with pytest.raises(OSError, match="database is read-only"):
+        rank_utils.save_ranks({"alice": {"last_ehb": 42.5, "rank": "Silver"}})
+
+
 def test_next_rank_returns_correct_next_rank(tmp_path, monkeypatch):
     ranks_data = {
         "player": {"last_ehb": 150, "rank": "Silver"}
@@ -88,10 +172,8 @@ def test_next_rank_returns_correct_next_rank(tmp_path, monkeypatch):
     assert result == "Gold at 200 EHB"
 
 
-def test_save_ranks_updates_sqlite_snapshot_when_ehb_changes(tmp_path, monkeypatch):
-    """upsert_players should be called when EHB differs from file."""
-
-    # Existing data with different EHB
+def test_save_ranks_updates_sqlite_snapshot(tmp_path, monkeypatch):
+    """save_ranks sends the sanitized snapshot to SQLite without rewriting JSON."""
     initial = {"player": {"last_ehb": 10, "rank": "Bronze"}}
     ranks_file = tmp_path / "player_ranks.json"
     with open(ranks_file, "w") as f:
@@ -119,11 +201,11 @@ def test_save_ranks_updates_sqlite_snapshot_when_ehb_changes(tmp_path, monkeypat
         "ehb": 42,
     }
     with open(ranks_file) as f:
-        assert json.load(f) == updated
+        assert json.load(f) == initial
 
 
-def test_save_ranks_skips_update_when_ehb_unchanged(tmp_path, monkeypatch):
-    """upsert_players should not be called if EHB has not changed."""
+def test_save_ranks_persists_complete_snapshot_when_ehb_unchanged(tmp_path, monkeypatch):
+    """SQLite receives the complete snapshot so it remains authoritative."""
 
     data = {"player": {"last_ehb": 42, "rank": "Bronze"}}
     ranks_file = tmp_path / "player_ranks.json"
@@ -132,17 +214,16 @@ def test_save_ranks_skips_update_when_ehb_unchanged(tmp_path, monkeypatch):
 
     monkeypatch.setattr(rank_utils, "RANKS_FILE", str(ranks_file))
 
-    called = {}
+    calls = []
 
     def fake_update(players):
-        called["called"] = True
+        calls.append(players)
 
     monkeypatch.setattr(rank_utils, "upsert_players", fake_update)
 
-    # Saving the same data again should not trigger an update
     rank_utils.save_ranks(data)
 
-    assert "called" not in called
+    assert calls == [data]
 
 
 def test_save_ranks_persists_and_upserts_total_xp_change(tmp_path, monkeypatch):
@@ -164,8 +245,10 @@ def test_save_ranks_persists_and_upserts_total_xp_change(tmp_path, monkeypatch):
     }
     rank_utils.save_ranks(updated)
 
-    assert json.loads(ranks_file.read_text()) == updated
     assert calls == [updated]
+    assert json.loads(ranks_file.read_text()) == {
+        "player": {"last_ehb": 42, "rank": "Bronze"}
+    }
 
 
 def test_load_ranks_returns_empty_on_corrupt_json(tmp_path, monkeypatch):
@@ -220,7 +303,7 @@ def test_next_rank_returns_max_rank_when_at_top(tmp_path, monkeypatch):
     assert result == "Max Rank Achieved 👑"
 
 
-def test_save_ranks_updates_only_changed_ehb(tmp_path, monkeypatch):
+def test_save_ranks_persists_all_players_in_one_batch(tmp_path, monkeypatch):
     old_data = {
         "alpha": {"last_ehb": 10, "rank": "Bronze"},
         "beta": {"last_ehb": 20, "rank": "Silver"},
@@ -245,7 +328,10 @@ def test_save_ranks_updates_only_changed_ehb(tmp_path, monkeypatch):
 
     rank_utils.save_ranks(new_data)
 
-    assert calls == [("beta", "Silver", 25)]
+    assert calls == [
+        ("alpha", "Bronze", 10),
+        ("beta", "Silver", 25),
+    ]
 
 
 # --- _get_rank_for_ehb ---

--- a/tests/test_rank_utils_ehp.py
+++ b/tests/test_rank_utils_ehp.py
@@ -106,35 +106,35 @@ def test_merge_manual_rank_update_does_not_add_ehp_to_legacy_row():
 def test_save_ranks_preserves_ehp_fields(tmp_path, monkeypatch):
     ranks_file = tmp_path / "player_ranks.json"
     monkeypatch.setattr(rank_utils, "RANKS_FILE", str(ranks_file))
-    monkeypatch.setattr(rank_utils, "upsert_players", lambda players: None)
 
     data = {"player": {"last_ehb": 42, "rank": "Bronze", "last_ehp": 120, "ehp_rank": "Stone"}}
     rank_utils.save_ranks(data)
 
-    assert json.loads(ranks_file.read_text()) == data
+    assert rank_utils.load_ranks() == data
+    assert not ranks_file.exists()
 
 
-def test_save_ranks_preserves_future_fields(tmp_path, monkeypatch):
+def test_save_ranks_persists_supported_fields_from_future_compatible_entry(tmp_path, monkeypatch):
     ranks_file = tmp_path / "player_ranks.json"
     monkeypatch.setattr(rank_utils, "RANKS_FILE", str(ranks_file))
-    monkeypatch.setattr(rank_utils, "upsert_players", lambda players: None)
     data = {"player": {"last_ehb": 42, "rank": "Bronze", "future_field": "keep-me"}}
 
     rank_utils.save_ranks(data)
 
-    assert json.loads(ranks_file.read_text()) == data
+    assert rank_utils.load_ranks() == {
+        "player": {"last_ehb": 42, "rank": "Bronze"}
+    }
 
 
 def test_save_ranks_omits_ehp_for_pre_ehp_rows(tmp_path, monkeypatch):
-    """Rows without EHP keys round-trip byte-for-byte (backward compatible)."""
+    """Rows without EHP keys remain distinguishable after a database round trip."""
     ranks_file = tmp_path / "player_ranks.json"
     monkeypatch.setattr(rank_utils, "RANKS_FILE", str(ranks_file))
-    monkeypatch.setattr(rank_utils, "upsert_players", lambda players: None)
 
     data = {"player": {"last_ehb": 42, "rank": "Bronze"}}
     rank_utils.save_ranks(data)
 
-    assert json.loads(ranks_file.read_text()) == {"player": {"last_ehb": 42, "rank": "Bronze"}}
+    assert rank_utils.load_ranks() == data
 
 
 def test_save_ranks_syncs_on_ehp_change(tmp_path, monkeypatch):

--- a/tests/test_rank_utils_extended.py
+++ b/tests/test_rank_utils_extended.py
@@ -40,11 +40,11 @@ def tmp_ranks_ini(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# save_ranks — first run (no existing JSON)
+# save_ranks — first run (no existing SQLite rows)
 # ---------------------------------------------------------------------------
 
-def test_save_ranks_creates_file_on_first_run(tmp_path, monkeypatch):
-    """save_ranks writes a new file when player_ranks.json does not yet exist."""
+def test_save_ranks_does_not_create_legacy_file_on_first_run(tmp_path, monkeypatch):
+    """save_ranks writes through SQLite without recreating player_ranks.json."""
     json_path = tmp_path / "player_ranks.json"
     monkeypatch.setattr(rank_utils, "RANKS_FILE", str(json_path))
 
@@ -54,9 +54,8 @@ def test_save_ranks_creates_file_on_first_run(tmp_path, monkeypatch):
     data = {"alice": {"last_ehb": 50.0, "rank": "Bronze"}}
     rank_utils.save_ranks(data)
 
-    assert json_path.exists()
-    saved = json.loads(json_path.read_text())
-    assert saved["alice"]["last_ehb"] == 50.0
+    assert calls == [data]
+    assert not json_path.exists()
 
 
 def test_save_ranks_syncs_to_sqlite_on_first_run(tmp_path, monkeypatch):
@@ -171,8 +170,8 @@ def test_load_ranks_empty_file_falls_back_to_bootstrap(tmp_path, monkeypatch):
     assert result == {}
 
 
-def test_load_ranks_preserves_unrecognized_fields(tmp_path, monkeypatch):
-    """load_ranks returns stored JSON without schema mutation."""
+def test_load_ranks_imports_only_supported_snapshot_fields(tmp_path, monkeypatch):
+    """Legacy JSON metadata outside the SQLite snapshot schema is ignored."""
     json_path = tmp_path / "player_ranks.json"
     data = {"dan": {"last_ehb": 10.0, "rank": "Bronze", "note": "legacy"}}
     json_path.write_text(json.dumps(data))
@@ -180,7 +179,7 @@ def test_load_ranks_preserves_unrecognized_fields(tmp_path, monkeypatch):
 
     result = rank_utils.load_ranks()
 
-    assert result == data
+    assert result == {"dan": {"last_ehb": 10.0, "rank": "Bronze"}}
 
 
 def test_load_ranks_missing_optional_fields_is_accepted(tmp_path, monkeypatch):


### PR DESCRIPTION
## What changed

- Make the existing SQLite `players` table the authoritative EHB/EHP rank snapshot store.
- Add an explicit `snapshot_initialized` marker so status-only player rows cannot suppress legacy migration.
- Load legacy `player_ranks.json` only when no initialized database snapshots exist, with the EHB CSV as the final fallback.
- Stop writing `player_ranks.json` during normal operation and propagate SQLite write failures.
- Update persistence documentation and add restart, migration, status-only-row, and write-failure regression coverage.

## Why

The Docker deployment persists `/app/data/database.db`, but `player_ranks.json` lived inside the disposable container. After a redeploy, the bot lost its EHP comparison baseline and treated every current EHP rank as a promotion, flooding Discord. SQLite already contained the required snapshot fields but was not used when loading ranks.

## Impact

Rank baselines now survive container recreation through the existing persistent database. Existing JSON snapshots migrate automatically on an empty database, and legacy CSV data remains supported as a final fallback.

## Validation

- `python -m compileall -q python`
- `pytest -q` — 190 passed
- Reconciled onto current `main`, preserving the newer achievement persistence tests and consolidated repository instructions.