### PR TITLE
Default the unauthenticated dashboard to loopback

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ A Discord bot that integrates with the Wise Old Man API to track EHB-based ranks
    gains_metrics = overall,ehb
 
    [web]
-   enabled = true
-   host = 0.0.0.0
+   enabled = false
+   host = 127.0.0.1
    port = 8080
    ```
 
@@ -65,7 +65,7 @@ Notes:
 - `api_key` is optional but helps with Wise Old Man rate limits.
 - EHP collection is opt-in. Set `track_ehp = true` to populate EHP ranks and history.
 - Gains snapshots default to a 7-day window collected daily. `gains_channel_id = 0` keeps the snapshots in SQLite without posting a Discord digest.
-- The web dashboard is disabled unless `[web] enabled = true`. Use `host = 0.0.0.0` in Docker so the published port can reach it; Docker Compose binds that port to host loopback by default. For a direct local run that should only be reachable from the same machine, use `host = 127.0.0.1`.
+- The web dashboard includes unauthenticated administrative controls, so it is disabled and bound to loopback by default. Only use `host = 0.0.0.0` inside Docker, where Docker Compose binds the published port to host loopback by default. Do not expose the dashboard to an untrusted network.
 - Keep your token/API values out of Git history.
 
 4. Copy `python/ranks.ini.example` to `python/ranks.ini`, then adjust the rank thresholds if needed:

--- a/python/WOM.py
+++ b/python/WOM.py
@@ -114,7 +114,7 @@ gains_metrics       = [m.strip() for m in config['settings'].get('gains_metrics'
 
 # Web interface settings
 web_enabled = config['web'].getboolean('enabled', False) if config.has_section('web') else False
-web_host = config['web'].get('host', '0.0.0.0') if config.has_section('web') else '0.0.0.0'
+web_host = config['web'].get('host', '127.0.0.1') if config.has_section('web') else '127.0.0.1'
 web_port = int(config['web'].get('port', '8080')) if config.has_section('web') else 8080
 
 if api_key:

--- a/python/web/app.py
+++ b/python/web/app.py
@@ -13,7 +13,7 @@ from .services.bot_state import BotState
 _BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-def create_app(state: BotState, host: str = "0.0.0.0", port: int = 8080, log_func=None) -> FastAPI:
+def create_app(state: BotState, host: str = "127.0.0.1", port: int = 8080, log_func=None) -> FastAPI:
     """Build and return the configured FastAPI application."""
 
     @asynccontextmanager


### PR DESCRIPTION
### Motivation
- The README and runtime defaults previously enabled the unauthenticated web admin on `0.0.0.0`, which risks accidental network exposure of admin actions and logs. 
- Make the deployment secure-by-default so operators must explicitly opt in to exposing the dashboard.

### Description
- Change the README sample `[web]` snippet to disable the dashboard by default and bind it to `127.0.0.1` instead of `0.0.0.0`, and add an explicit warning about unauthenticated admin controls. 
- Change the runtime fallback in `python/WOM.py` so `web_host` defaults to `127.0.0.1` when no host is configured. 
- Change the FastAPI application factory in `python/web/app.py` so `create_app()` defaults its `host` parameter to `127.0.0.1` to keep behavior consistent and secure-by-default. 

### Testing
- `git diff --check` completed without whitespace or patch errors. 
- `pytest` was run and all tests passed (`175 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6545977a348326b7b0aa50bf170d4f)